### PR TITLE
Windows path fixes

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -653,7 +653,7 @@ function pbxFileReferenceObj(file) {
     obj.lastKnownFileType = file.lastType;
     
     obj.name = "\"" + file.basename + "\"";
-    obj.path = "\"" + file.path + "\"";
+    obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
     
     obj.sourceTree = file.sourceTree;
 
@@ -695,28 +695,22 @@ function longComment(file) {
 
 // respect <group> path
 function correctForPluginsPath(file, project) {
-    var r_plugin_dir = /^Plugins\//;
-
-    if (project.pbxGroupByName('Plugins').path)
-        file.path = file.path.replace(r_plugin_dir, '');
-
-    return file;
+    return correctForPath(file, project, 'Plugins');
 }
 
 function correctForResourcesPath(file, project) {
-    var r_resources_dir = /^Resources\//;
-
-    if (project.pbxGroupByName('Resources').path)
-        file.path = file.path.replace(r_resources_dir, '');
-
-    return file;
+    return correctForPath(file, project, 'Resources');
 }
 
 function correctForFrameworksPath(file, project) {
-    var r_resources_dir = /^Frameworks\//;
+    return correctForPath(file, project, 'Frameworks');
+}
 
-    if (project.pbxGroupByName('Frameworks').path)
-        file.path = file.path.replace(r_resources_dir, '');
+function correctForPath(file, project, group) {
+    var r_group_dir = new RegExp('^' + group + '[\\\\/]');
+
+    if (project.pbxGroupByName(group).path)
+        file.path = file.path.replace(r_group_dir, '');
 
     return file;
 }

--- a/test/pbxProject.js
+++ b/test/pbxProject.js
@@ -184,6 +184,28 @@ exports['productName field'] = {
     }
 }
 
+exports['addPluginFile function'] = {
+    'should strip the Plugin path prefix': function (test) {
+        var myProj = new pbx('test/parser/projects/full.pbxproj');
+
+        myProj.parse(function (err, hash) {
+            test.equal(myProj.addPluginFile('Plugins/testMac.m').path, 'testMac.m');
+            test.equal(myProj.addPluginFile('Plugins\\testWin.m').path, 'testWin.m');
+            test.done();
+        });
+    },
+    'should add files to the .pbxproj file using the / path seperator': function (test) {
+        var myProj = new pbx('test/parser/projects/full.pbxproj');
+
+        myProj.parse(function (err, hash) {
+            var file = myProj.addPluginFile('myPlugin\\newFile.m');
+
+            test.equal(myProj.pbxFileReferenceSection()[file.fileRef].path, '"myPlugin/newFile.m"');
+            test.done();
+        });
+    }
+}
+
 exports['hasFile'] = {
     'should return true if the file is in the project': function (test) {
         var newProj = new pbx('.');


### PR DESCRIPTION
The _pbxFileReferenceObj_ function fails when run on a Windows machine. On Windows the file.path contains backslashes instead of slashes (if the file is in a subdirectory), thus creating an invalid entry into the .pbxproj file.

Also, the _correctForPluginsPath_, _correctForResourcesPath_ and _correctForFrameworksPath_ functions try to fix paths by removing a specific part followed by a slash. These also fail when run on a Windows machine due to assuming the backslash as path seperator.

You can see this incorrect behaviour for example in the _.pbxproj_ file when adding plugins to a Cordova project on a Windows machine.

These suggested changes make those functions work with both slash and backslash path seperators.
