### PR TITLE
adds updateBuildProperty for changing custom build settings

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -445,9 +445,13 @@ pbxProject.prototype.buildPhaseObject = function (name, group) {
     return null;
 }
 
-pbxProject.prototype.updateProductName = function(name) {
+pbxProject.prototype.updateBuildProperty = function(prop, value) {
     var config = this.pbxXCBuildConfigurationSection();
-    propReplace(config, 'PRODUCT_NAME', '"' + name + '"');
+    propReplace(config, prop, value);
+}
+
+pbxProject.prototype.updateProductName = function(name) {
+    this.updateBuildProperty('PRODUCT_NAME', '"' + name + '"');
 }
 
 pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {


### PR DESCRIPTION
This method is very usefull since it allows changing custom build properties like TARGETED_DEVICE_FAMILY or IPHONEOS_DEPLOYMENT_TARGET

This is going to be used in Apache Cordova for iOS platform
