### PR TITLE
Support string args to add lib/include path

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -546,7 +546,11 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
             buildSettings['LIBRARY_SEARCH_PATHS'] = [INHERITED];
         }
 
-        buildSettings['LIBRARY_SEARCH_PATHS'].push(searchPathForFile(file, this));
+        if (typeof file === 'string') {
+            buildSettings['LIBRARY_SEARCH_PATHS'].push(file);
+        } else {
+            buildSettings['LIBRARY_SEARCH_PATHS'].push(searchPathForFile(file, this));
+        }
     }
 }
 
@@ -590,7 +594,11 @@ pbxProject.prototype.addToHeaderSearchPaths = function (file) {
             buildSettings['HEADER_SEARCH_PATHS'] = [INHERITED];
         }
 
-        buildSettings['HEADER_SEARCH_PATHS'].push(searchPathForFile(file, this));
+        if (typeof file === 'string') {
+            buildSettings['HEADER_SEARCH_PATHS'].push(file);
+        } else {
+            buildSettings['HEADER_SEARCH_PATHS'].push(searchPathForFile(file, this));
+        }
     }
 }
 // a JS getter. hmmm

--- a/test/HeaderSearchPaths.js
+++ b/test/HeaderSearchPaths.js
@@ -28,6 +28,17 @@ exports.addAndRemoveToFromHeaderSearchPaths = {
         }
         test.done();
     },
+    'add should not mangle string arguments and add to each config section':function(test) {
+        var includePath = '../../some/path';
+        proj.addToHeaderSearchPaths(includePath);
+        var config = proj.pbxXCBuildConfigurationSection();
+        for (var ref in config) {
+            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            var lib = config[ref].buildSettings.HEADER_SEARCH_PATHS;
+            test.ok(lib[1].indexOf(includePath) > -1);
+        }
+        test.done();
+    },
     'remove should remove from the path to each configuration section':function(test) {
         var libPath = 'some/path/include';
         proj.addToHeaderSearchPaths({

--- a/test/LibrarySearchPaths.js
+++ b/test/LibrarySearchPaths.js
@@ -28,6 +28,17 @@ exports.addAndRemoveToFromLibrarySearchPaths = {
         }
         test.done();
     },
+    'add should not mangle string arguments and add to each config section':function(test) {
+        var libPath = '../../some/path';
+        proj.addToLibrarySearchPaths(libPath);
+        var config = proj.pbxXCBuildConfigurationSection();
+        for (var ref in config) {
+            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            var lib = config[ref].buildSettings.LIBRARY_SEARCH_PATHS;
+            test.ok(lib[1].indexOf(libPath) > -1);
+        }
+        test.done();
+    },
     'remove should remove from the path to each configuration section':function(test) {
         var libPath = 'some/path/poop.a';
         proj.addToLibrarySearchPaths({


### PR DESCRIPTION
addToLibrarySearchPaths and addToHeaderSearchPaths previously assumed
that the file argument was a `pbxFile`, and that the added reference
should be of a certain format. However, this prevents a user from adding
a relative path such as '../../../sharedDependency/include' or similar.
This patch adds support for that functionality.