### PR TITLE
XCBuildConfiguration array field replace ok

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -633,7 +633,7 @@ pbxProject.prototype.hasFile = function (filePath) {
 function propReplace(obj, prop, value) {
     for (var p in obj) {
         if (obj.hasOwnProperty(p)) {
-            if (typeof obj[p] == 'object') {
+            if (typeof obj[p] == 'object' && !Array.isArray(obj[p])) {
                 propReplace(obj[p], prop, value);
             } else if (p == prop) {
                 obj[p] = value;

--- a/test/pbxProject.js
+++ b/test/pbxProject.js
@@ -169,6 +169,9 @@ exports['updateBuildProperty function'] = {
             myProj.updateBuildProperty('TARGETED_DEVICE_FAMILY', '"arm"');
             var newContents = myProj.writeSync();
             test.ok(newContents.match(/TARGETED_DEVICE_FAMILY\s*=\s*"arm"/));
+            myProj.updateBuildProperty('OTHER_LDFLAGS', ['T','E','S','T']);
+            newContents = myProj.writeSync();
+            test.ok(newContents.match(/OTHER_LDFLAGS\s*=\s*\(\s*T,\s*E,\s*S,\s*T,\s*\)/))
             test.done();
         });
     }


### PR DESCRIPTION
Fixes XCBuildConfiguration's array field replacing
ex)
GCC_PREPROCESSOR_DEFINITIONS = (
	"COCOS2D_DEBUG=1",
	USE_FILE32API,
	CC_TARGET_OS_IPHONE,
);
