### PR TITLE
Fixes issue #44, where removeFromPbxFileReferenceSection fails to remove...

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -277,7 +277,9 @@ pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
     var refObj = pbxFileReferenceObj(file);
     for(i in this.pbxFileReferenceSection()) {
         if(this.pbxFileReferenceSection()[i].name == refObj.name ||
-           this.pbxFileReferenceSection()[i].path == refObj.path) {
+           ('"' + this.pbxFileReferenceSection()[i].name + '"') == refObj.name ||
+           this.pbxFileReferenceSection()[i].path == refObj.path ||
+           ('"' + this.pbxFileReferenceSection()[i].path + '"') == refObj.path) {
             file.fileRef = file.uuid = i;
             delete this.pbxFileReferenceSection()[i];
             break;

--- a/test/removeSourceFile.js
+++ b/test/removeSourceFile.js
@@ -126,6 +126,21 @@ exports.removeSourceFile = {
 
         test.ok(!sourceObj);
         test.done();
+    },
+    'should remove file from PBXFileReference after modified by Xcode': function(test) {
+        var fileRef = proj.addSourceFile('Plugins/file.m').fileRef;
+
+        // Simulate Xcode's behaviour of stripping quotes around path and name
+        // properties.
+        var entry = proj.pbxFileReferenceSection()[fileRef];
+        entry.name = entry.name.replace(/^"(.*)"$/, "$1");
+        entry.path = entry.path.replace(/^"(.*)"$/, "$1");
+
+        var newFile = proj.removeSourceFile('Plugins/file.m');
+
+        test.ok(newFile.uuid);
+        test.ok(!proj.pbxFileReferenceSection()[fileRef]);
+        test.done();
     }
 }
 


### PR DESCRIPTION
... its given file from PBXFileReference.

Check both quoted and unquoted name and path to make sure removeFromPbxFileReferenceSection will properly remove its given file from PBXFileReference.