### PR TITLE
Added double quotes around COMPILER_FLAGS

### DIFF
--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -1,4 +1,5 @@
 var path = require('path'),
+    util = require('util'),
     M_EXTENSION = /[.]m$/, SOURCE_FILE = 'sourcecode.c.objc',
     H_EXTENSION = /[.]h$/, HEADER_FILE = 'sourcecode.c.h',
     BUNDLE_EXTENSION = /[.]bundle$/, BUNDLE = '"wrapper.plug-in"',
@@ -93,7 +94,7 @@ function pbxFile(filepath, opt) {
     if (opt.compilerFlags) {
         if (!this.settings)
           this.settings = {};
-        this.settings.COMPILER_FLAGS = opt.compilerFlags;
+          this.settings.COMPILER_FLAGS = util.format('"%s"', opt.compilerFlags);
     }
 }
 

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -195,9 +195,9 @@ exports['settings'] = {
 
     'should be {COMPILER_FLAGS:"blah"} if compiler flags specified': function (test) {
         var sourceFile = new pbxFile('Plugins/BarcodeScanner.m',
-            { compilerFlags: "-fno-objc-arc" });
+            { compilerFlags: "-std=c++11 -fno-objc-arc" });
 
-        test.deepEqual({COMPILER_FLAGS:"-fno-objc-arc"}, sourceFile.settings);
+        test.deepEqual({COMPILER_FLAGS:'"-std=c++11 -fno-objc-arc"'}, sourceFile.settings);
         test.done();
     }
 }


### PR DESCRIPTION
Adding COMPILER_FLAGS with = or space corrupts the project file and it can not be parsed by xcode or xcodebuild
I tested how xcode behaves and it adds quotes around the COMPILER_FLAGS setting, but it doesn't add quotes to Weak from ATTRIBUTES.
This is the reason this fix is applied only when opt.compilerFlags is present