### PR TITLE
Fix AddBuildPhase able to add duplicate files

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -400,6 +400,8 @@ pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function (file) {
 
 pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
     var section = this.hash.project.objects[isa],
+        fileReferenceSection = this.pbxFileReferenceSection(),
+        buildFileSection = this.pbxBuildFileSection(),
         buildPhaseUuid = this.generateUuid(),
         commentKey = f("%s_comment", buildPhaseUuid),
         buildPhase = {
@@ -407,12 +409,37 @@ pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
             buildActionMask: 2147483647,
             files: [],
             runOnlyForDeploymentPostprocessing: 0
-        };
+        },
+        filePathToBuildFile = {};
+    
+    for (var key in buildFileSection) {
+        // only look for comments
+        if (!COMMENT_KEY.test(key)) continue;
+        
+        var buildFileKey = key.split(COMMENT_KEY)[0],
+            buildFile = buildFileSection[buildFileKey];
+            fileReference = fileReferenceSection[buildFile.fileRef];
+
+        if (!fileReference) continue;
+
+        var pbxFileObj = new pbxFile(fileReference.path);
+        
+        filePathToBuildFile[fileReference.path] = {uuid: buildFileKey, basename: pbxFileObj.basename, group: pbxFileObj.group};
+    }
 
     for (var index = 0; index < filePathsArray.length; index++) {
         var filePath = filePathsArray[index],
+            filePathQuoted = "\"" + filePath + "\"",
             file = new pbxFile(filePath);
 
+        if (filePathToBuildFile[filePath]) {
+            buildPhase.files.push(pbxBuildPhaseObj(filePathToBuildFile[filePath]));
+            continue;
+        } else if (filePathToBuildFile[filePathQuoted]) {
+            buildPhase.files.push(pbxBuildPhaseObj(filePathToBuildFile[filePathQuoted]));
+            continue;
+        }
+        
         file.uuid = this.generateUuid();
         file.fileRef = this.generateUuid();
         this.addToPbxFileReferenceSection(file);    // PBXFileReference

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -425,8 +425,7 @@ pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
         section[commentKey] = comment;
     }
     
-    buildPhase.uuid = buildPhaseUuid;
-    return buildPhase;
+    return {uuid: buildPhaseUuid, buildPhase: buildPhase};
 }
 
 // helper access functions

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -26,7 +26,7 @@ exports.addBuildPhase = {
         test.done()
     },
     'should add all files to build phase': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase');
+        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase;
         for (var index = 0; index < buildPhase.files.length; index++) {
             var file = buildPhase.files[index];
             test.ok(file.value);
@@ -35,7 +35,7 @@ exports.addBuildPhase = {
         test.done()
     },
     'should add the PBXBuildPhase object correctly': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase'),
+        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
             buildPhaseInPbx = proj.buildPhaseObject('PBXResourcesBuildPhase', 'My build phase');
 
         test.equal(buildPhaseInPbx, buildPhase);
@@ -45,7 +45,7 @@ exports.addBuildPhase = {
         test.done();
     },
     'should add each of the files to PBXBuildFile section': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase'),
+        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
             buildFileSection = proj.pbxBuildFileSection();
         
         for (var index = 0; index < buildPhase.files.length; index++) {
@@ -56,7 +56,7 @@ exports.addBuildPhase = {
         test.done();
     },
     'should add each of the files to PBXFileReference section': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase'),
+        var buildPhase = proj.addBuildPhase(['file.m', 'assets.bundle'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
             fileRefSection = proj.pbxFileReferenceSection(),
             buildFileSection = proj.pbxBuildFileSection(),
             fileRefs = [];

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -62,15 +62,47 @@ exports.addBuildPhase = {
             fileRefs = [];
         
         for (var index = 0; index < buildPhase.files.length; index++) {
-            var file = buildPhase.files[index];
-            fileRefs.push(buildFileSection[file.value].fileRef);
-        }
-        
-        for (var index = 0; index < fileRefs.length; index++) {
-            var fileRef = fileRefs[index];
+            var file = buildPhase.files[index],
+                fileRef = buildFileSection[file.value].fileRef;
+                
             test.ok(fileRefSection[fileRef]);            
         }
 
+        test.done();
+    },
+    'should not add files to PBXFileReference section if already added': function (test) {
+        var fileRefSection = proj.pbxFileReferenceSection(),
+            initialFileReferenceSectionItemsCount = Object.keys(fileRefSection),
+            buildPhase = proj.addBuildPhase(['AppDelegate.m', 'main.m'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
+            afterAdditionBuildFileSectionItemsCount = Object.keys(fileRefSection);
+        
+        test.deepEqual(initialFileReferenceSectionItemsCount, afterAdditionBuildFileSectionItemsCount);
+        test.done();
+    },
+    'should not add files to PBXBuildFile section if already added': function (test) {
+        var buildFileSection  = proj.pbxBuildFileSection(),
+            initialBuildFileSectionItemsCount  = Object.keys(buildFileSection),
+            buildPhase = proj.addBuildPhase(['AppDelegate.m', 'main.m'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
+            afterAdditionBuildFileSectionItemsCount = Object.keys(buildFileSection);
+        
+        test.deepEqual(initialBuildFileSectionItemsCount, afterAdditionBuildFileSectionItemsCount);
+        test.done();
+    },
+    'should add only missing files to PBXFileReference section': function (test) {
+        var fileRefSection = proj.pbxFileReferenceSection(),
+            buildFileSection = proj.pbxBuildFileSection(),
+            initialFileReferenceSectionItemsCount = Object.keys(fileRefSection),
+            buildPhase = proj.addBuildPhase(['file.m', 'AppDelegate.m'], 'PBXResourcesBuildPhase', 'My build phase').buildPhase,
+            afterAdditionBuildFileSectionItemsCount = Object.keys(fileRefSection);
+        
+        for (var index = 0; index < buildPhase.files.length; index++) {
+            var file = buildPhase.files[index],
+                fileRef = buildFileSection[file.value].fileRef;
+                
+            test.ok(fileRefSection[fileRef]);            
+        }
+        
+        test.deepEqual(initialFileReferenceSectionItemsCount.length, afterAdditionBuildFileSectionItemsCount.length - 2);
         test.done();
     }
 }


### PR DESCRIPTION
Upon adding a build phase an unnecessary property is added, namely uuid