### PR TITLE
Add new Targets (e.g., Extensions), including corresponding dependencies

### DIFF
--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -91,43 +91,59 @@ function defaultExtension(fileRef) {
     return extension;
 }
 
+function defaultEncoding(fileRef) {
+    var encoding = ENCODING_BY_FILETYPE[fileRef.lastKnownFileType];
 
-    // dunno
-    return 'unknown';
-}
-
-function fileEncoding(file) {
-    if (file.lastType != BUNDLE && !file.customFramework) {
-        return DEFAULT_FILE_ENCODING;
+    if (encoding) {
+        return encoding;
     }
 }
 
-function defaultSourceTree(file) {
-    if (( file.lastType == DYLIB || file.lastType == FRAMEWORK ) && !file.customFramework) {
-        return 'SDKROOT';
-    } else {
-        return DEFAULT_SOURCE_TREE;
+function defaultGroup(fileRef) {
+    var groupName = GROUP_BY_FILETYPE[fileRef.lastKnownFileType];
+
+    if (!groupName) {
+        return DEFAULT_GROUP;
     }
+
+    return groupName;
 }
 
-function correctPath(file, filepath) {
-    if (file.lastType == FRAMEWORK && !file.customFramework) {
-        return 'System/Library/Frameworks/' + filepath;
-    } else if (file.lastType == DYLIB) {
-        return 'usr/lib/' + filepath;
-    } else {
-        return filepath;
+function defaultSourcetree(fileRef) {
+    var sourcetree = SOURCETREE_BY_FILETYPE[fileRef.lastKnownFileType];
+
+    if (fileRef.customFramework) {
+        return filePath;
     }
+
+    if (fileRef.explicitFileType) {
+        return DEFAULT_PRODUCT_SOURCETREE;
+    }
+
+    return sourcetree;
 }
 
-function correctGroup(file) {
-    if (file.lastType == SOURCE_FILE) {
-        return 'Sources';
-    } else if (file.lastType == DYLIB || file.lastType == ARCHIVE || file.lastType == FRAMEWORK) {
-        return 'Frameworks';
-    } else {
-        return 'Resources';
+function defaultPath(fileRef, filePath) {
+    var defaultPath = PATH_BY_FILETYPE[fileRef.lastKnownFileType];
+
+    if (fileRef.customFramework) {
+        return filePath;
     }
+    if (defaultPath) {
+        return path.join(defaultPath, filePath);
+    }
+
+    return filePath;
+}
+
+function defaultGroup(fileRef) {
+    var groupName = GROUP_BY_FILETYPE[fileRef.lastKnownFileType];
+
+    if (!groupName) {
+        return DEFAULT_GROUP;
+    }
+
+    return defaultGroup;
 }
 
 function pbxFile(filepath, opt) {
@@ -136,9 +152,9 @@ function pbxFile(filepath, opt) {
     this.lastType = opt.lastType || detectLastType(filepath);
 
     // for custom frameworks
-    if(opt.customFramework == true) {
-      this.customFramework = true;
-      this.dirname = path.dirname(filepath);
+    if (opt.customFramework == true) {
+        this.customFramework = true;
+        this.dirname = path.dirname(filepath);
     }
 
     this.basename = path.basename(filepath);
@@ -149,12 +165,12 @@ function pbxFile(filepath, opt) {
     this.fileEncoding = opt.fileEncoding || fileEncoding(this);
 
     if (opt.weak && opt.weak === true) 
-      this.settings = { ATTRIBUTES: ['Weak'] };
+        this.settings = { ATTRIBUTES: ['Weak'] };
 
     if (opt.compilerFlags) {
         if (!this.settings)
-          this.settings = {};
-          this.settings.COMPILER_FLAGS = util.format('"%s"', opt.compilerFlags);
+            this.settings = {};
+        this.settings.COMPILER_FLAGS = util.format('"%s"', opt.compilerFlags);
     }
 }
 

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -150,6 +150,7 @@ function pbxFile(filepath, opt) {
     var opt = opt || {};
 
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
+    this.group = defaultGroup(this);
 
     // for custom frameworks
     if (opt.customFramework == true) {
@@ -158,11 +159,21 @@ function pbxFile(filepath, opt) {
     }
 
     this.basename = path.basename(filepath);
-    this.path = correctPath(this, filepath);
-    this.group = correctGroup(this);
+    this.path = defaultPath(this, filepath);
+    this.defaultEncoding = opt.defaultEncoding || defaultEncoding(this);
 
-    this.sourceTree = opt.sourceTree || defaultSourceTree(this);
-    this.fileEncoding = opt.fileEncoding || fileEncoding(this);
+
+    // When referencing products / build output files
+    if (opt.explicitFileType) {
+        this.explicitFileType = opt.explicitFileType;
+        this.basename = this.basename + '.' + defaultExtension(this);
+        delete this.path;
+        delete this.lastKnownFileType;
+        delete this.group;
+        delete this.defaultEncoding;
+    }
+
+    this.sourceTree = opt.sourceTree || defaultSourcetree(this);
 
     if (opt.weak && opt.weak === true) 
         this.settings = { ATTRIBUTES: ['Weak'] };

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -1,14 +1,74 @@
 var path = require('path'),
-    util = require('util'),
-    M_EXTENSION = /[.]m$/, SOURCE_FILE = 'sourcecode.c.objc',
-    H_EXTENSION = /[.]h$/, HEADER_FILE = 'sourcecode.c.h',
-    BUNDLE_EXTENSION = /[.]bundle$/, BUNDLE = '"wrapper.plug-in"',
-    XIB_EXTENSION = /[.]xib$/, XIB_FILE = 'file.xib',
-    DYLIB_EXTENSION = /[.]dylib$/, DYLIB = '"compiled.mach-o.dylib"',
-    FRAMEWORK_EXTENSION = /[.]framework/, FRAMEWORK = 'wrapper.framework',
-    ARCHIVE_EXTENSION = /[.]a$/, ARCHIVE = 'archive.ar',
-    DEFAULT_SOURCE_TREE = '"<group>"',
-    DEFAULT_FILE_ENCODING = 4;
+    util = require('util');
+
+var DEFAULT_SOURCETREE = '"<group>"',
+    DEFAULT_PRODUCT_SOURCETREE = 'BUILT_PRODUCTS_DIR',
+    DEFAULT_FILEENCODING = 4,
+    DEFAULT_GROUP = 'Resources',
+    DEFAULT_FILETYPE = 'unknown';
+
+var FILETYPE_BY_EXTENSION = {
+        a: 'archive.ar',
+        app: 'wrapper.application',
+        appex: 'wrapper.app-extension',
+        bundle: 'wrapper.plug-in',
+        dylib: 'compiled.mach-o.dylib',
+        framework: 'wrapper.framework',
+        h: 'sourcecode.c.h',
+        m: 'sourcecode.c.objc',
+        markdown: 'text',
+        mdimporter: 'wrapper.cfbundle',
+        octest: 'wrapper.cfbundle',
+        pch: 'sourcecode.c.h',
+        plist: 'text.plist.xml',
+        sh: 'text.script.sh',
+        swift: 'sourcecode.swift',
+        xcassets: 'folder.assetcatalog',
+        xcconfig: 'text.xcconfig',
+        xcdatamodel: 'wrapper.xcdatamodel',
+        xcodeproj: 'wrapper.pb-project',
+        xctest: 'wrapper.cfbundle',
+        xib: 'file.xib'
+    },
+    EXTENSION_BY_PRODUCTTYPE = {
+        'com.apple.product-type.application': 'app',
+        'com.apple.product-type.application.watchapp': 'app',
+        'com.apple.product-type.app-extension': 'appex',
+        'com.apple.product-type.watchkit-extension': 'appex',
+        'com.apple.product-type.bundle': 'bundle',
+        'com.apple.product-type.bundle.unit-test': 'xctest',
+        'com.apple.product-type.framework': 'framework',
+        'com.apple.product-type.library.dynamic': 'dylib',
+        'com.apple.product-type.library.static': 'a',
+        'com.apple.product-type.tool': ''
+    },
+    GROUP_BY_FILETYPE = {
+        'archive.ar': 'Frameworks',
+        'compiled.mach-o.dylib': 'Frameworks',
+        'wrapper.framework': 'Frameworks',
+        'sourcecode.c.h': 'Sources',
+        'sourcecode.c.objc': 'Sources',
+        'sourcecode.swift': 'Sources'
+    },
+    PATH_BY_FILETYPE = {
+        'compiled.mach-o.dylib': 'usr/lib/',
+        'wrapper.framework': 'System/Library/Frameworks/'
+    },
+    SOURCETREE_BY_FILETYPE = {
+        'compiled.mach-o.dylib': 'SDKROOT',
+        'wrapper.framework': 'SDKROOT'
+    },
+    ENCODING_BY_FILETYPE = {
+        'sourcecode.c.h': 4,
+        'sourcecode.c.h': 4,
+        'sourcecode.c.objc': 4,
+        'sourcecode.swift': 4,
+        'text': 4,
+        'text.plist.xml': 4,
+        'text.script.sh': 4,
+        'text.xcconfig': 4
+    };
+
 
 function detectLastType(path) {
     if (M_EXTENSION.test(path))

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -81,8 +81,15 @@ function detectType(filePath) {
     return type;
 }
 
+function defaultExtension(fileRef) {
+    var extension = EXTENSION_BY_PRODUCTTYPE[fileRef.explicitFileType];
 
+    if (!extension) {
+        return;
+    }
 
+    return extension;
+}
 
 
     // dunno

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -149,7 +149,7 @@ function defaultGroup(fileRef) {
 function pbxFile(filepath, opt) {
     var opt = opt || {};
 
-    this.lastType = opt.lastType || detectLastType(filepath);
+    this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
 
     // for custom frameworks
     if (opt.customFramework == true) {

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -30,18 +30,6 @@ var FILETYPE_BY_EXTENSION = {
         xctest: 'wrapper.cfbundle',
         xib: 'file.xib'
     },
-    EXTENSION_BY_PRODUCTTYPE = {
-        'com.apple.product-type.application': 'app',
-        'com.apple.product-type.application.watchapp': 'app',
-        'com.apple.product-type.app-extension': 'appex',
-        'com.apple.product-type.watchkit-extension': 'appex',
-        'com.apple.product-type.bundle': 'bundle',
-        'com.apple.product-type.bundle.unit-test': 'xctest',
-        'com.apple.product-type.framework': 'framework',
-        'com.apple.product-type.library.dynamic': 'dylib',
-        'com.apple.product-type.library.static': 'a',
-        'com.apple.product-type.tool': ''
-    },
     GROUP_BY_FILETYPE = {
         'archive.ar': 'Frameworks',
         'compiled.mach-o.dylib': 'Frameworks',
@@ -82,13 +70,14 @@ function detectType(filePath) {
 }
 
 function defaultExtension(fileRef) {
-    var extension = EXTENSION_BY_PRODUCTTYPE[fileRef.explicitFileType];
+    var filetype = fileRef.explicitFileType.replace(/^"|"$/g, '');
 
-    if (!extension) {
-        return;
+    for(var extension in FILETYPE_BY_EXTENSION) {
+        if(FILETYPE_BY_EXTENSION.hasOwnProperty(extension) ) {
+             if(FILETYPE_BY_EXTENSION[extension] === filetype )
+                 return extension;
+        }
     }
-
-    return extension;
 }
 
 function defaultEncoding(fileRef) {
@@ -175,7 +164,7 @@ function pbxFile(filepath, opt) {
 
     this.sourceTree = opt.sourceTree || defaultSourcetree(this);
 
-    if (opt.weak && opt.weak === true) 
+    if (opt.weak && opt.weak === true)
         this.settings = { ATTRIBUTES: ['Weak'] };
 
     if (opt.compilerFlags) {

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -70,27 +70,20 @@ var FILETYPE_BY_EXTENSION = {
     };
 
 
-function detectLastType(path) {
-    if (M_EXTENSION.test(path))
-        return SOURCE_FILE;
+function detectType(filePath) {
+    var extension = path.extname(filePath),
+        type = FILETYPE_BY_EXTENSION[extension];
 
-    if (H_EXTENSION.test(path))
-        return HEADER_FILE;
+    if (!type) {
+        return DEFAULT_FILETYPE;
+    }
 
-    if (BUNDLE_EXTENSION.test(path))
-        return BUNDLE;
+    return type;
+}
 
-    if (XIB_EXTENSION.test(path))
-        return XIB_FILE;
 
-    if (FRAMEWORK_EXTENSION.test(path))
-        return FRAMEWORK;
 
-    if (DYLIB_EXTENSION.test(path))
-        return DYLIB;
 
-    if (ARCHIVE_EXTENSION.test(path))
-        return ARCHIVE;
 
     // dunno
     return 'unknown';

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1050,7 +1050,6 @@ function pbxFileReferenceObj(file) {
     var obj = Object.create(null);
 
     obj.isa = 'PBXFileReference';
-    obj.lastKnownFileType = file.lastType;
 
     obj.name = "\"" + file.basename + "\"";
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -245,6 +245,59 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
     return file;
 }
 
+
+pbxProject.prototype.addCopyfile = function(fpath, opt) {
+    var file = new pbxFile(fpath, opt);
+
+    // catch duplicates
+    if (this.hasFile(file.path)) {
+        file = this.hasFile(file.path);
+    } else {
+        file.uuid = this.generateUuid();
+        file.fileRef = this.generateUuid();
+    }
+
+    file.target = opt ? opt.target : undefined;
+    file.group = 'CopyFiles';
+
+
+    this.addToPbxBuildFileSection(file);        // PBXBuildFile
+    this.addToPbxFileReferenceSection(file);    // PBXFileReference
+    this.addToPbxCopyfilesBuildPhase(file);     // PBXCopyFilesBuildPhase
+
+    return file;
+}
+
+pbxProject.prototype.pbxCopyfilesBuildPhaseObj = function(target) {
+    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'CopyFiles', target);
+}
+
+pbxProject.prototype.addToPbxCopyfilesBuildPhase = function(file) {
+    var sources = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'CopyFiles', file.target);
+    sources.files.push(pbxBuildPhaseObj(file));
+}
+
+pbxProject.prototype.removeCopyfile = function(fpath, opt) {
+    var file = new pbxFile(fpath, opt);
+    file.target = opt ? opt.target : undefined;
+
+    this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
+    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
+    this.removeFromPbxCopyfilesBuildPhase(file);    // PBXFrameworksBuildPhase
+
+    return file;
+}
+
+pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function(file) {
+    var sources = this.pbxCopyfilesBuildPhaseObj(file.target);
+    for (i in sources.files) {
+        if (sources.files[i].comment == longComment(file)) {
+            sources.files.splice(i, 1);
+            break;
+        }
+    }
+}
+
 pbxProject.prototype.addStaticLibrary = function(path, opt) {
     opt = opt || {};
 
@@ -1114,6 +1167,42 @@ function pbxBuildPhaseObj(file) {
 
     obj.value = file.uuid;
     obj.comment = longComment(file);
+
+    return obj;
+}
+
+function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName){
+
+     // Add additional properties for 'CopyFiles' build phase
+    var DESTINATION_BY_TARGETTYPE = {
+        application: 'wrapper',
+        app_extension: 'plugins',
+        bundle: 'wrapper',
+        command_line_tool: 'wrapper',
+        dynamic_library: 'products_directory',
+        framework: 'shared_frameworks',
+        static_library: 'products_directory',
+        unit_test_bundle: 'wrapper',
+        watch_app: 'wrapper',
+        watch_extension: 'plugins'
+    }
+    var SUBFOLDERSPEC_BY_DESTINATION = {
+        absolute_path: 0,
+        executables: 6,
+        frameworks: 10,
+        java_resources: 15,
+        plugins: 13,
+        products_directory: 16,
+        resources: 7,
+        shared_frameworks: 11,
+        shared_support: 12,
+        wrapper: 1,
+        xpc_services: 0
+    }
+
+    obj.name = phaseName || '""';
+    obj.dstPath = subfolderPath || '""';
+    obj.dstSubfolderSpec = SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType]];
 
     return obj;
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1097,7 +1097,7 @@ function pbxBuildFileComment(file) {
 }
 
 function pbxFileReferenceComment(file) {
-    return path.basename(file.path);
+    return file.basename || path.basename(file.path);
 }
 
 function pbxNativeTargetComment(target) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -926,7 +926,7 @@ pbxProject.prototype.hasFile = function(filePath) {
     for (id in files) {
         file = files[id];
         if (file.path == filePath || file.path == ('"' + filePath + '"')) {
-            return true;
+            return file;
         }
     }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -642,15 +642,14 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     return { uuid: target, target: nativeTargets[target] };
 }
 
-pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, comment, target, folderType, subfolderPath) {
-    var buildPhaseSection,
+pbxProject.prototype.addBuildPhase = function(filePathsArray, addToType, comment, folderType, subfolderPath) {
+    var buildPhaseSection = this.hash.project.objects[addToType],
         fileReferenceSection = this.pbxFileReferenceSection(),
         buildFileSection = this.pbxBuildFileSection(),
-        buildPhaseUuid = this.generateUuid(),
-        buildPhaseTargetUuid = target || this.getFirstTarget().uuid,
-        commentKey = f("%s_comment", buildPhaseUuid),
-        buildPhase = {
-            isa: buildPhaseType,
+        phaseUuid = this.generateUuid(),
+        commentKey = f("%s_comment", phaseUuid),
+        buildPhaseRef = {
+            isa: addToType,
             buildActionMask: 2147483647,
             files: [],
             runOnlyForDeploymentPostprocessing: 0
@@ -658,28 +657,10 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
         filePathToBuildFile = {};
 
 
-    if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
-        buildPhase = pbxCopyFilesBuildPhaseObj(buildPhase, folderType, subfolderPath, comment);
-        buildPhase.name = comment;
+    // Add CopyFiles BuildPhase template
+    if (addToType === 'PBXCopyFilesBuildPhase') {
+        buildPhaseRef = pbxCopyFilesBuildPhaseObj(buildPhaseRef, folderType, subfolderPath, comment);
     }
-
-    if (!this.hash.project.objects[buildPhaseType]) {
-        this.hash.project.objects[buildPhaseType] = new Object();
-        this.hash.project.objects[buildPhaseType][buildPhaseUuid] = buildPhase;
-        this.hash.project.objects[buildPhaseType][commentKey] = comment;
-
-
-        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases'].push({
-            value: buildPhaseUuid,
-            comment: comment
-        })
-
-                console.log(util.inspect(this.hash.project.objects['PBXNativeTarget'], true, null));
-
-    }
-
-
-    buildPhase = this.hash.project.objects[buildPhaseType];
 
 
     for (var key in buildFileSection) {
@@ -714,15 +695,15 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
         file.fileRef = this.generateUuid();
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
         this.addToPbxBuildFileSection(file);        // PBXBuildFile
-        buildPhase.files.push(pbxBuildPhaseObj(file));
+        buildPhaseRef.files.push(pbxBuildPhaseObj(file));
     }
 
     if (buildPhaseSection) {
-        buildPhaseSection[buildPhaseUuid] = buildPhase;
+        buildPhaseSection[phaseUuid] = buildPhaseRef;
         buildPhaseSection[commentKey] = comment;
-    }
+        }
 
-    return { uuid: buildPhaseUuid, buildPhase: buildPhase };
+    return { uuid: phaseUuid, buildPhase: buildPhaseRef };
 }
 
 // helper access functions
@@ -1083,8 +1064,7 @@ pbxProject.prototype.addTarget = function(name, type) {
     if (targetType === 'app_extension') {
         // Create "Copy Files" build phase for target which contains the extension
         this.addToPbxBuildFileSection(productFile);
-        var newPhase = this.addBuildPhase([productFileName], 'PBXCopyFilesBuildPhase', 'Copy Files', targetType)
-        this.addBuildPhaseToTarget(newPhase.buildPhase, this.getFirstTarget().uuid)
+        this.addBuildPhase([productFileName], 'PBXCopyFilesBuildPhase', 'Copy Files', targetType)
     };
 
     // Target: Add uuid to root project
@@ -1200,7 +1180,7 @@ function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName){
         xpc_services: 0
     }
 
-    obj.name = phaseName || '""';
+    obj.name = '"' + phaseName + '"' || '""';
     obj.dstPath = subfolderPath || '""';
     obj.dstSubfolderSpec = SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType]];
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -355,6 +355,13 @@ pbxProject.prototype.addToPbxProjectSection = function(target) {
     this.pbxProjectSection()[this.getFirstProject()['uuid']]['targets'].push(newTarget);
 }
 
+pbxProject.prototype.addToPbxNativeTargetSection = function(target) {
+    var commentKey = f("%s_comment", target.uuid);
+
+    this.pbxNativeTargetSection()[target.uuid] = target.pbxNativeTarget;
+    this.pbxNativeTargetSection()[commentKey] = target.pbxNativeTarget.name;
+}
+
 pbxProject.prototype.addToPbxFileReferenceSection = function(file) {
     var commentKey = f("%s_comment", file.fileRef);
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -113,8 +113,9 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
 
     file.includeInIndex = 0;
     file.fileRef = this.generateUuid();
+    file.target = opt ? opt.target : undefined;
+    file.group = opt ? opt.group : undefined;
 
-    this.addToPbxFileReferenceSection(file);         // PBXFileReference
     this.addToProductsPbxGroup(file);                // PBXGroup
 
     return file;
@@ -123,7 +124,6 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
 pbxProject.prototype.removeProductFile = function(path, opt) {
     var file = new pbxFile(path, opt);
 
-    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
     this.removeFromProductsPbxGroup(file);           // PBXGroup
 
     return file;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1032,7 +1032,7 @@ pbxProject.prototype.addTarget = function(name, type) {
             isa: 'XCBuildConfiguration',
             buildSettings: {
                 GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
-                INFOPLIST_FILE: targetName + '-Info.Plist',
+                INFOPLIST_FILE: '"' + path.join(targetName, targetName + '-Info.plist' + '"'),
                 LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
                 PRODUCT_NAME: targetName,
                 SKIP_INSTALL: 'YES'
@@ -1042,7 +1042,7 @@ pbxProject.prototype.addTarget = function(name, type) {
             name: 'Release',
             isa: 'XCBuildConfiguration',
             buildSettings: {
-                INFOPLIST_FILE: targetName + '-Info.Plist',
+                INFOPLIST_FILE: '"' + path.join(targetName, targetName + '-Info.plist' + '"'),
                 LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
                 PRODUCT_NAME: targetName,
                 SKIP_INSTALL: 'YES'

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1300,6 +1300,24 @@ function producttypeForTargettype (targetType) {
     return PRODUCTTYPE_BY_TARGETTYPE[targetType]
 }
 
+function filetypeForProducttype (productType) {
+
+    FILETYPE_BY_PRODUCTTYPE = {
+            'com.apple.product-type.application': '"wrapper.application"',
+            'com.apple.product-type.app-extension': '"wrapper.app-extension"',
+            'com.apple.product-type.bundle': '"wrapper.plug-in"',
+            'com.apple.product-type.tool': '"compiled.mach-o.dylib"',
+            'com.apple.product-type.library.dynamic': '"compiled.mach-o.dylib"',
+            'com.apple.product-type.framework': '"wrapper.framework"',
+            'com.apple.product-type.library.static': '"archive.ar"',
+            'com.apple.product-type.bundle.unit-test': '"wrapper.cfbundle"',
+            'com.apple.product-type.application.watchapp': '"wrapper.application"',
+            'com.apple.product-type.watchkit-extension': '"wrapper.app-extension"'
+        };
+
+    return FILETYPE_BY_PRODUCTTYPE[productType]
+}
+
 pbxProject.prototype.getFirstProject = function() {
 
     // Get pbxProject container

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -115,7 +115,10 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
     file.fileRef = this.generateUuid();
     file.target = opt ? opt.target : undefined;
     file.group = opt ? opt.group : undefined;
+    file.uuid = this.generateUuid();
+    file.path = file.basename;
 
+    this.addToPbxFileReferenceSection(file);
     this.addToProductsPbxGroup(file);                // PBXGroup
 
     return file;
@@ -208,9 +211,8 @@ pbxProject.prototype.removeResourceFile = function(path, opt) {
 }
 
 pbxProject.prototype.addFramework = function(fpath, opt) {
+
     var file = new pbxFile(fpath, opt);
-    // catch duplicates
-    if (this.hasFile(file.path)) return false;
 
     file.uuid = this.generateUuid();
     file.fileRef = this.generateUuid();
@@ -252,14 +254,10 @@ pbxProject.prototype.addCopyfile = function(fpath, opt) {
     // catch duplicates
     if (this.hasFile(file.path)) {
         file = this.hasFile(file.path);
-    } else {
-        file.uuid = this.generateUuid();
-        file.fileRef = this.generateUuid();
     }
 
+    file.fileRef = file.uuid = this.generateUuid();
     file.target = opt ? opt.target : undefined;
-    file.group = 'CopyFiles';
-
 
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxFileReferenceSection(file);    // PBXFileReference
@@ -269,11 +267,11 @@ pbxProject.prototype.addCopyfile = function(fpath, opt) {
 }
 
 pbxProject.prototype.pbxCopyfilesBuildPhaseObj = function(target) {
-    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'CopyFiles', target);
+    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Copy Files', target);
 }
 
 pbxProject.prototype.addToPbxCopyfilesBuildPhase = function(file) {
-    var sources = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'CopyFiles', file.target);
+    var sources = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Copy Files', file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 }
 
@@ -642,24 +640,40 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     return { uuid: target, target: nativeTargets[target] };
 }
 
-pbxProject.prototype.addBuildPhase = function(filePathsArray, addToType, comment, folderType, subfolderPath) {
-    var buildPhaseSection = this.hash.project.objects[addToType],
+pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, comment, target, folderType, subfolderPath) {
+    var buildPhaseSection,
         fileReferenceSection = this.pbxFileReferenceSection(),
         buildFileSection = this.pbxBuildFileSection(),
-        phaseUuid = this.generateUuid(),
-        commentKey = f("%s_comment", phaseUuid),
-        buildPhaseRef = {
-            isa: addToType,
+        buildPhaseUuid = this.generateUuid(),
+        buildPhaseTargetUuid = target || this.getFirstTarget().uuid,
+        commentKey = f("%s_comment", buildPhaseUuid),
+        buildPhase = {
+            isa: buildPhaseType,
             buildActionMask: 2147483647,
             files: [],
             runOnlyForDeploymentPostprocessing: 0
         },
         filePathToBuildFile = {};
 
+    if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
+        buildPhase = pbxCopyFilesBuildPhaseObj(buildPhase, folderType, subfolderPath, comment);
+    }
 
-    // Add CopyFiles BuildPhase template
-    if (addToType === 'PBXCopyFilesBuildPhase') {
-        buildPhaseRef = pbxCopyFilesBuildPhaseObj(buildPhaseRef, folderType, subfolderPath, comment);
+    if (!this.hash.project.objects[buildPhaseType]) {
+        this.hash.project.objects[buildPhaseType] = new Object();
+    }
+
+    if (!this.hash.project.objects[buildPhaseType][buildPhaseUuid]) {
+        this.hash.project.objects[buildPhaseType][buildPhaseUuid] = buildPhase;
+        this.hash.project.objects[buildPhaseType][commentKey] = comment;
+    }
+
+    if (this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases']) {
+        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases'].push({
+            value: buildPhaseUuid,
+            comment: comment
+        })
+
     }
 
 
@@ -695,15 +709,15 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, addToType, comment
         file.fileRef = this.generateUuid();
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
         this.addToPbxBuildFileSection(file);        // PBXBuildFile
-        buildPhaseRef.files.push(pbxBuildPhaseObj(file));
+        buildPhase.files.push(pbxBuildPhaseObj(file));
     }
 
     if (buildPhaseSection) {
-        buildPhaseSection[phaseUuid] = buildPhaseRef;
+        buildPhaseSection[buildPhaseUuid] = buildPhase;
         buildPhaseSection[commentKey] = comment;
-        }
+    }
 
-    return { uuid: phaseUuid, buildPhase: buildPhaseRef };
+    return { uuid: buildPhaseUuid, buildPhase: buildPhase };
 }
 
 // helper access functions
@@ -993,11 +1007,12 @@ pbxProject.prototype.hasFile = function(filePath) {
     return false;
 }
 
-pbxProject.prototype.addTarget = function(name, type) {
+pbxProject.prototype.addTarget = function(name, type, subfolder) {
 
     // Setup uuid and name of new target
     var targetUuid = this.generateUuid(),
         targetType = type,
+        targetSubfolder = subfolder,
         targetName = name.trim();
 
     // Check type against list of allowed target types
@@ -1013,9 +1028,9 @@ pbxProject.prototype.addTarget = function(name, type) {
             isa: 'XCBuildConfiguration',
             buildSettings: {
                 GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
-                INFOPLIST_FILE: '"' + path.join(targetName, targetName + '-Info.plist' + '"'),
+                INFOPLIST_FILE: '"' + path.join(targetSubfolder, targetSubfolder + '-Info.plist' + '"'),
                 LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-                PRODUCT_NAME: targetName,
+                PRODUCT_NAME: '"' + targetName + '"',
                 SKIP_INSTALL: 'YES'
             }
         },
@@ -1023,9 +1038,9 @@ pbxProject.prototype.addTarget = function(name, type) {
             name: 'Release',
             isa: 'XCBuildConfiguration',
             buildSettings: {
-                INFOPLIST_FILE: '"' + path.join(targetName, targetName + '-Info.plist' + '"'),
+                INFOPLIST_FILE: '"' + path.join(targetSubfolder, targetSubfolder + '-Info.plist' + '"'),
                 LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-                PRODUCT_NAME: targetName,
+                PRODUCT_NAME: '"' + targetName + '"',
                 SKIP_INSTALL: 'YES'
             }
         }
@@ -1038,16 +1053,20 @@ pbxProject.prototype.addTarget = function(name, type) {
     var productName = targetName,
         productType = producttypeForTargettype(targetType),
         productFileType = filetypeForProducttype(productType),
-        productFile = this.addProductFile(productName, { 'target': targetUuid,  'explicitFileType': productFileType}),
+        productFile = this.addProductFile(productName, { group: 'Copy Files', 'target': targetUuid, 'explicitFileType': productFileType}),
         productFileName = productFile.basename;
+
+
+    // Product: Add to build file list
+    this.addToPbxBuildFileSection(productFile);
 
     // Target: Create
     var target = {
             uuid: targetUuid,
             pbxNativeTarget: {
                 isa: 'PBXNativeTarget',
-                name: targetName,
-                productName: targetName,
+                name: '"' + targetName + '"',
+                productName: '"' + targetName + '"',
                 productReference: productFile.fileRef,
                 productType: '"' + producttypeForTargettype(targetType) + '"',
                 buildConfigurationList: buildConfigurations.uuid,
@@ -1062,9 +1081,15 @@ pbxProject.prototype.addTarget = function(name, type) {
 
     // Product: Embed (only for "extension"-type targets)
     if (targetType === 'app_extension') {
-        // Create "Copy Files" build phase for target which contains the extension
-        this.addToPbxBuildFileSection(productFile);
-        this.addBuildPhase([productFileName], 'PBXCopyFilesBuildPhase', 'Copy Files', targetType)
+
+        // Create CopyFiles phase in first target
+        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Copy Files', this.getFirstTarget().uuid,  targetType)
+
+        // Add product to CopyFiles phase
+        this.addToPbxCopyfilesBuildPhase(productFile)
+
+       // this.addBuildPhaseToTarget(newPhase.buildPhase, this.getFirstTarget().uuid)
+
     };
 
     // Target: Add uuid to root project
@@ -1180,7 +1205,7 @@ function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName){
         xpc_services: 0
     }
 
-    obj.name = '"' + phaseName + '"' || '""';
+    obj.name = '"' + phaseName + '"';
     obj.dstPath = subfolderPath || '""';
     obj.dstSubfolderSpec = SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType]];
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1051,21 +1051,23 @@ pbxProject.prototype.addTarget = function(name, type) {
     ];
 
     // Build Configuration: Add
-    var buildConfigurations = this.addXCConfigurationList(buildConfigurationsList, 'Release', 'Build configuration list for PBXNativeTarget "' + targetName +'"'),
-        buildConfigurationsUuid = buildConfigurations.uuid;
+    var buildConfigurations = this.addXCConfigurationList(buildConfigurationsList, 'Release', 'Build configuration list for PBXNativeTarget "' + targetName +'"');
 
     // Product: Create
     var productName = targetName,
         productType = producttypeForTargettype(targetType),
-        productFile = this.addProductFile(productName, { 'explicitFileType': productType }),
+        productFileType = filetypeForProducttype(productType),
+        productFile = this.addProductFile(productName, { 'target': targetUuid, 'group': 'CopyFiles' }),
         productFileName = productFile.basename;
 
-    // Product: Embed in first target (only for "extension"-type targets)
+    // Product: Embed (only for "extension"-type targets)
     if (targetType === 'app_extension') {
-        var embedPhase;
-        var embedFile;
 
-        // TODO: Add embedding via "PBXCopyFilesBuildPhase" build phase
+        // Create "Copy Files" build phase for target which contains the extension
+        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'CopyFiles', this.getFirstTarget().uuid)
+
+        // Add product reference to "Copy Files" build phase
+        this.addCopyfile(productFileName, { 'explicitFileType': productFileType, 'target': this.getFirstTarget().uuid })
     };
 
     // Target: Create
@@ -1077,7 +1079,7 @@ pbxProject.prototype.addTarget = function(name, type) {
                 productName: targetName,
                 productReference: productFile.fileRef,
                 productType: '"' + producttypeForTargettype(targetType) + '"',
-                buildConfigurationList: buildConfigurationsUuid,
+                buildConfigurationList: buildConfigurations.uuid,
                 buildPhases: [],
                 buildRules: [],
                 dependencies: []

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -662,7 +662,7 @@ pbxProject.prototype.pbxFileReferenceSection = function() {
     return this.hash.project.objects['PBXFileReference'];
 }
 
-pbxProject.prototype.pbxNativeTarget = function () {
+pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
@@ -713,7 +713,7 @@ pbxProject.prototype.buildPhase = function(group, target) {
     if (!target)
         return undefined;
 
-     var nativeTargets = this.pbxNativeTarget();
+    var nativeTargets = this.pbxNativeTargetSection();
      if (typeof nativeTargets[target] == "undefined")
         throw new Error("Invalid target: " + target);
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -589,19 +589,45 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     return { uuid: target, target: nativeTargets[target] };
 }
 
-pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
-    var section = this.hash.project.objects[isa],
+pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, comment, target, folderType, subfolderPath) {
+    var buildPhaseSection,
         fileReferenceSection = this.pbxFileReferenceSection(),
         buildFileSection = this.pbxBuildFileSection(),
         buildPhaseUuid = this.generateUuid(),
+        buildPhaseTargetUuid = target || this.getFirstTarget().uuid,
         commentKey = f("%s_comment", buildPhaseUuid),
         buildPhase = {
-            isa: isa,
+            isa: buildPhaseType,
             buildActionMask: 2147483647,
             files: [],
             runOnlyForDeploymentPostprocessing: 0
         },
         filePathToBuildFile = {};
+
+
+    if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
+        buildPhase = pbxCopyFilesBuildPhaseObj(buildPhase, folderType, subfolderPath, comment);
+        buildPhase.name = comment;
+    }
+
+    if (!this.hash.project.objects[buildPhaseType]) {
+        this.hash.project.objects[buildPhaseType] = new Object();
+        this.hash.project.objects[buildPhaseType][buildPhaseUuid] = buildPhase;
+        this.hash.project.objects[buildPhaseType][commentKey] = comment;
+
+
+        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases'].push({
+            value: buildPhaseUuid,
+            comment: comment
+        })
+
+                console.log(util.inspect(this.hash.project.objects['PBXNativeTarget'], true, null));
+
+    }
+
+
+    buildPhase = this.hash.project.objects[buildPhaseType];
+
 
     for (var key in buildFileSection) {
         // only look for comments
@@ -638,9 +664,9 @@ pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
         buildPhase.files.push(pbxBuildPhaseObj(file));
     }
 
-    if (section) {
-        section[buildPhaseUuid] = buildPhase;
-        section[commentKey] = comment;
+    if (buildPhaseSection) {
+        buildPhaseSection[buildPhaseUuid] = buildPhase;
+        buildPhaseSection[commentKey] = comment;
     }
 
     return { uuid: buildPhaseUuid, buildPhase: buildPhase };

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -19,10 +19,10 @@ function pbxProject(filename) {
 
 util.inherits(pbxProject, EventEmitter)
 
-pbxProject.prototype.parse = function (cb) {
+pbxProject.prototype.parse = function(cb) {
     var worker = fork(__dirname + '/parseJob.js', [this.filepath])
 
-    worker.on('message', function (msg) {
+    worker.on('message', function(msg) {
         if (msg.name == 'SyntaxError' || msg.code) {
             this.emit('error', msg);
         } else {
@@ -39,19 +39,19 @@ pbxProject.prototype.parse = function (cb) {
     return this;
 }
 
-pbxProject.prototype.parseSync = function () {
+pbxProject.prototype.parseSync = function() {
     var file_contents = fs.readFileSync(this.filepath, 'utf-8');
 
     this.hash = parser.parse(file_contents);
     return this;
 }
 
-pbxProject.prototype.writeSync = function () {
+pbxProject.prototype.writeSync = function() {
     this.writer = new pbxWriter(this.hash);
     return this.writer.writeSync();
 }
 
-pbxProject.prototype.allUuids = function () {
+pbxProject.prototype.allUuids = function() {
     var sections = this.hash.project.objects,
         uuids = [],
         section;
@@ -61,18 +61,18 @@ pbxProject.prototype.allUuids = function () {
         uuids = uuids.concat(Object.keys(section))
     }
 
-    uuids = uuids.filter(function (str) {
+    uuids = uuids.filter(function(str) {
         return !COMMENT_KEY.test(str) && str.length == 24;
     });
 
     return uuids;
 }
 
-pbxProject.prototype.generateUuid = function () {
+pbxProject.prototype.generateUuid = function() {
     var id = uuid.v4()
-                .replace(/-/g,'')
-                .substr(0,24)
-                .toUpperCase()
+        .replace(/-/g, '')
+        .substr(0, 24)
+        .toUpperCase()
 
     if (this.allUuids().indexOf(id) >= 0) {
         return this.generateUuid();
@@ -81,7 +81,7 @@ pbxProject.prototype.generateUuid = function () {
     }
 }
 
-pbxProject.prototype.addPluginFile = function (path, opt) {
+pbxProject.prototype.addPluginFile = function(path, opt) {
     var file = new pbxFile(path, opt);
 
     file.plugin = true; // durr
@@ -98,7 +98,7 @@ pbxProject.prototype.addPluginFile = function (path, opt) {
     return file;
 }
 
-pbxProject.prototype.removePluginFile = function (path, opt) {
+pbxProject.prototype.removePluginFile = function(path, opt) {
     var file = new pbxFile(path, opt);
     correctForPluginsPath(file, this);
 
@@ -108,9 +108,29 @@ pbxProject.prototype.removePluginFile = function (path, opt) {
     return file;
 }
 
+pbxProject.prototype.addProductFile = function(targetPath, opt) {
+    var file = new pbxFile(targetPath, opt);
 
-pbxProject.prototype.addSourceFile = function (path, opt) {
-  
+    file.includeInIndex = 0;
+    file.fileRef = this.generateUuid();
+
+    this.addToPbxFileReferenceSection(file);         // PBXFileReference
+    this.addToProductsPbxGroup(file);                // PBXGroup
+
+    return file;
+}
+
+pbxProject.prototype.removeProductFile = function(path, opt) {
+    var file = new pbxFile(path, opt);
+
+    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
+    this.removeFromProductsPbxGroup(file);           // PBXGroup
+
+    return file;
+}
+
+pbxProject.prototype.addSourceFile = function(path, opt) {
+
     var file = this.addPluginFile(path, opt);
     if (!file) return false;
 
@@ -124,7 +144,7 @@ pbxProject.prototype.addSourceFile = function (path, opt) {
 }
 
 
-pbxProject.prototype.removeSourceFile = function (path, opt) {
+pbxProject.prototype.removeSourceFile = function(path, opt) {
     var file = this.removePluginFile(path, opt)
     file.target = opt ? opt.target : undefined;
     this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
@@ -133,15 +153,15 @@ pbxProject.prototype.removeSourceFile = function (path, opt) {
     return file;
 }
 
-pbxProject.prototype.addHeaderFile = function (path, opt) {
+pbxProject.prototype.addHeaderFile = function(path, opt) {
     return this.addPluginFile(path, opt)
 }
 
-pbxProject.prototype.removeHeaderFile = function (path, opt) {
+pbxProject.prototype.removeHeaderFile = function(path, opt) {
     return this.removePluginFile(path, opt)
 }
 
-pbxProject.prototype.addResourceFile = function (path, opt) {
+pbxProject.prototype.addResourceFile = function(path, opt) {
     opt = opt || {};
 
     var file;
@@ -173,27 +193,27 @@ pbxProject.prototype.addResourceFile = function (path, opt) {
     return file;
 }
 
-pbxProject.prototype.removeResourceFile = function (path, opt) {
+pbxProject.prototype.removeResourceFile = function(path, opt) {
     var file = new pbxFile(path, opt);
     file.target = opt ? opt.target : undefined;
-    
+
     correctForResourcesPath(file, this);
 
     this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
     this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
     this.removeFromResourcesPbxGroup(file);          // PBXGroup
     this.removeFromPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
-    
+
     return file;
 }
 
-pbxProject.prototype.addFramework = function (fpath, opt) {
+pbxProject.prototype.addFramework = function(fpath, opt) {
     var file = new pbxFile(fpath, opt);
     // catch duplicates
     if (this.hasFile(file.path)) return false;
 
     file.uuid = this.generateUuid();
-    file.fileRef = this.generateUuid();    
+    file.fileRef = this.generateUuid();
     file.target = opt ? opt.target : undefined;
 
 
@@ -201,15 +221,15 @@ pbxProject.prototype.addFramework = function (fpath, opt) {
     this.addToPbxFileReferenceSection(file);    // PBXFileReference
     this.addToFrameworksPbxGroup(file);         // PBXGroup
     this.addToPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
-    
-    if(opt && opt.customFramework == true) {
-      this.addToFrameworkSearchPaths(file);
+
+    if (opt && opt.customFramework == true) {
+        this.addToFrameworkSearchPaths(file);
     }
 
     return file;
 }
 
-pbxProject.prototype.removeFramework = function (fpath, opt) {
+pbxProject.prototype.removeFramework = function(fpath, opt) {
     var file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
@@ -217,15 +237,15 @@ pbxProject.prototype.removeFramework = function (fpath, opt) {
     this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
     this.removeFromFrameworksPbxGroup(file);         // PBXGroup
     this.removeFromPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
-    
-    if(opt && opt.customFramework) {
-      this.removeFromFrameworkSearchPaths(path.dirname(fpath));
+
+    if (opt && opt.customFramework) {
+        this.removeFromFrameworkSearchPaths(path.dirname(fpath));
     }
 
     return file;
 }
 
-pbxProject.prototype.addStaticLibrary = function (path, opt) {
+pbxProject.prototype.addStaticLibrary = function(path, opt) {
     opt = opt || {};
 
     var file;
@@ -254,18 +274,18 @@ pbxProject.prototype.addStaticLibrary = function (path, opt) {
 }
 
 // helper addition functions
-pbxProject.prototype.addToPbxBuildFileSection = function (file) {
+pbxProject.prototype.addToPbxBuildFileSection = function(file) {
     var commentKey = f("%s_comment", file.uuid);
 
     this.pbxBuildFileSection()[file.uuid] = pbxBuildFileObj(file);
     this.pbxBuildFileSection()[commentKey] = pbxBuildFileComment(file);
 }
 
-pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
+pbxProject.prototype.removeFromPbxBuildFileSection = function(file) {
     var uuid;
 
-    for(uuid in this.pbxBuildFileSection()) {
-        if(this.pbxBuildFileSection()[uuid].fileRef_comment == file.basename) {
+    for (uuid in this.pbxBuildFileSection()) {
+        if (this.pbxBuildFileSection()[uuid].fileRef_comment == file.basename) {
             file.uuid = uuid;
             delete this.pbxBuildFileSection()[uuid];
         }
@@ -274,7 +294,7 @@ pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
     delete this.pbxBuildFileSection()[commentKey];
 }
 
-pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceTree) {
+pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTree) {
     var groups = this.hash.project.objects['PBXGroup'],
         pbxGroupUuid = this.generateUuid(),
         commentKey = f("%s_comment", pbxGroupUuid),
@@ -287,15 +307,15 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
         },
         fileReferenceSection = this.pbxFileReferenceSection(),
         filePathToReference = {};
-        
+
     for (var key in fileReferenceSection) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
-        
+
         var fileReferenceKey = key.split(COMMENT_KEY)[0],
             fileReference = fileReferenceSection[fileReferenceKey];
-        
-        filePathToReference[fileReference.path] = {fileRef: fileReferenceKey, basename: fileReferenceSection[key]};
+
+        filePathToReference[fileReference.path] = { fileRef: fileReferenceKey, basename: fileReferenceSection[key] };
     }
 
     for (var index = 0; index < filePathsArray.length; index++) {
@@ -308,7 +328,7 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
             pbxGroup.children.push(pbxGroupChild(filePathToReference[filePathQuoted]));
             continue;
         }
-        
+
         var file = new pbxFile(filePath);
         file.uuid = this.generateUuid();
         file.fileRef = this.generateUuid();
@@ -316,149 +336,167 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
         this.addToPbxBuildFileSection(file);        // PBXBuildFile
         pbxGroup.children.push(pbxGroupChild(file));
     }
-    
+
     if (groups) {
         groups[pbxGroupUuid] = pbxGroup;
         groups[commentKey] = name;
     }
-    
-    return {uuid: pbxGroupUuid, pbxGroup: pbxGroup};
+
+    return { uuid: pbxGroupUuid, pbxGroup: pbxGroup };
 }
 
-pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
+pbxProject.prototype.addToPbxFileReferenceSection = function(file) {
     var commentKey = f("%s_comment", file.fileRef);
 
     this.pbxFileReferenceSection()[file.fileRef] = pbxFileReferenceObj(file);
     this.pbxFileReferenceSection()[commentKey] = pbxFileReferenceComment(file);
 }
 
-pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
+pbxProject.prototype.removeFromPbxFileReferenceSection = function(file) {
 
     var i;
     var refObj = pbxFileReferenceObj(file);
-    for(i in this.pbxFileReferenceSection()) {
-        if(this.pbxFileReferenceSection()[i].name == refObj.name ||
-           ('"' + this.pbxFileReferenceSection()[i].name + '"') == refObj.name ||
-           this.pbxFileReferenceSection()[i].path == refObj.path ||
-           ('"' + this.pbxFileReferenceSection()[i].path + '"') == refObj.path) {
+    for (i in this.pbxFileReferenceSection()) {
+        if (this.pbxFileReferenceSection()[i].name == refObj.name ||
+            ('"' + this.pbxFileReferenceSection()[i].name + '"') == refObj.name ||
+            this.pbxFileReferenceSection()[i].path == refObj.path ||
+            ('"' + this.pbxFileReferenceSection()[i].path + '"') == refObj.path) {
             file.fileRef = file.uuid = i;
             delete this.pbxFileReferenceSection()[i];
             break;
         }
     }
     var commentKey = f("%s_comment", file.fileRef);
-    if(this.pbxFileReferenceSection()[commentKey] != undefined) {
+    if (this.pbxFileReferenceSection()[commentKey] != undefined) {
         delete this.pbxFileReferenceSection()[commentKey];
     }
 
     return file;
 }
 
-pbxProject.prototype.addToPluginsPbxGroup = function (file) {
+pbxProject.prototype.addToPluginsPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Plugins');
     pluginsGroup.children.push(pbxGroupChild(file));
 }
 
-pbxProject.prototype.removeFromPluginsPbxGroup = function (file) {
+pbxProject.prototype.removeFromPluginsPbxGroup = function(file) {
     var pluginsGroupChildren = this.pbxGroupByName('Plugins').children, i;
-    for(i in pluginsGroupChildren) {
-        if(pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-           pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+    for (i in pluginsGroupChildren) {
+        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
 }
 
-pbxProject.prototype.addToResourcesPbxGroup = function (file) {
+pbxProject.prototype.addToResourcesPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Resources');
     pluginsGroup.children.push(pbxGroupChild(file));
 }
 
-pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
+pbxProject.prototype.removeFromResourcesPbxGroup = function(file) {
     var pluginsGroupChildren = this.pbxGroupByName('Resources').children, i;
-    for(i in pluginsGroupChildren) {
-        if(pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-           pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+    for (i in pluginsGroupChildren) {
+        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
 }
 
-pbxProject.prototype.addToFrameworksPbxGroup = function (file) {
+pbxProject.prototype.addToFrameworksPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Frameworks');
     pluginsGroup.children.push(pbxGroupChild(file));
 }
 
-pbxProject.prototype.removeFromFrameworksPbxGroup = function (file) {
+pbxProject.prototype.removeFromFrameworksPbxGroup = function(file) {
     var pluginsGroupChildren = this.pbxGroupByName('Frameworks').children;
-    
-    for(i in pluginsGroupChildren) {
-        if(pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-           pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+
+    for (i in pluginsGroupChildren) {
+        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
 }
-pbxProject.prototype.addToPbxSourcesBuildPhase = function (file) {
+
+
+pbxProject.prototype.addToProductsPbxGroup = function(file) {
+    var productsGroup = this.pbxGroupByName('Products');
+    productsGroup.children.push(pbxGroupChild(file));
+}
+
+pbxProject.prototype.removeFromProductsPbxGroup = function(file) {
+    var productsGroupChildren = this.pbxGroupByName('Products').children, i;
+    for (i in productsGroupChildren) {
+        if (pbxGroupChild(file).value == productsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == productsGroupChildren[i].comment) {
+            productsGroupChildren.splice(i, 1);
+            break;
+        }
+    }
+}
+
+pbxProject.prototype.addToPbxSourcesBuildPhase = function(file) {
     var sources = this.pbxSourcesBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 }
 
-pbxProject.prototype.removeFromPbxSourcesBuildPhase = function (file) {
+pbxProject.prototype.removeFromPbxSourcesBuildPhase = function(file) {
 
     var sources = this.pbxSourcesBuildPhaseObj(file.target), i;
-    for(i in sources.files) {
-        if(sources.files[i].comment == longComment(file)) {
+    for (i in sources.files) {
+        if (sources.files[i].comment == longComment(file)) {
             sources.files.splice(i, 1);
-            break; 
+            break;
         }
     }
 }
 
-pbxProject.prototype.addToPbxResourcesBuildPhase = function (file) {
+pbxProject.prototype.addToPbxResourcesBuildPhase = function(file) {
     var sources = this.pbxResourcesBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 }
 
-pbxProject.prototype.removeFromPbxResourcesBuildPhase = function (file) {
+pbxProject.prototype.removeFromPbxResourcesBuildPhase = function(file) {
     var sources = this.pbxResourcesBuildPhaseObj(file.target), i;
 
-    for(i in sources.files) {
-        if(sources.files[i].comment == longComment(file)) {
+    for (i in sources.files) {
+        if (sources.files[i].comment == longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
     }
 }
 
-pbxProject.prototype.addToPbxFrameworksBuildPhase = function (file) {
+pbxProject.prototype.addToPbxFrameworksBuildPhase = function(file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 }
 
-pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function (file) {
+pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function(file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
-    for(i in sources.files) {
-        if(sources.files[i].comment == longComment(file)) {
+    for (i in sources.files) {
+        if (sources.files[i].comment == longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
     }
 }
 
-pbxProject.prototype.addXCConfigurationList = function (configurationObjectsArray, defaultConfigurationName, comment) {
+pbxProject.prototype.addXCConfigurationList = function(configurationObjectsArray, defaultConfigurationName, comment) {
     var pbxBuildConfigurationSection = this.pbxXCBuildConfigurationSection(),
-        pbxXCConfigurationListSection = this.pbxXCConfigurationList(), 
+        pbxXCConfigurationListSection = this.pbxXCConfigurationList(),
         xcConfigurationListUuid = this.generateUuid(),
         commentKey = f("%s_comment", xcConfigurationListUuid),
-        xcConfigurationList = { 
+        xcConfigurationList = {
             isa: 'XCConfigurationList',
             buildConfigurations: [],
             defaultConfigurationIsVisible: 0,
-            defaultConfigurationName: defaultConfigurationName 
+            defaultConfigurationName: defaultConfigurationName
         };
 
     for (var index = 0; index < configurationObjectsArray.length; index++) {
@@ -468,18 +506,18 @@ pbxProject.prototype.addXCConfigurationList = function (configurationObjectsArra
 
         pbxBuildConfigurationSection[configurationUuid] = configuration;
         pbxBuildConfigurationSection[configurationCommentKey] = configuration.name;
-        xcConfigurationList.buildConfigurations.push({value: configurationUuid, comment: configuration.name});
+        xcConfigurationList.buildConfigurations.push({ value: configurationUuid, comment: configuration.name });
     }
-    
+
     if (pbxXCConfigurationListSection) {
         pbxXCConfigurationListSection[xcConfigurationListUuid] = xcConfigurationList;
         pbxXCConfigurationListSection[commentKey] = comment;
     }
-    
-    return {uuid: xcConfigurationListUuid, xcConfigurationList: xcConfigurationList};
+
+    return { uuid: xcConfigurationListUuid, xcConfigurationList: xcConfigurationList };
 }
 
-pbxProject.prototype.addTargetDependency = function (target, dependencyTargets) {
+pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     if (!target)
         return undefined;
 
@@ -487,13 +525,13 @@ pbxProject.prototype.addTargetDependency = function (target, dependencyTargets) 
 
     if (typeof nativeTargets[target] == "undefined")
         throw new Error("Invalid target: " + target);
-        
+
     for (var index = 0; index < dependencyTargets.length; index++) {
         var dependencyTarget = dependencyTargets[index];
         if (typeof nativeTargets[dependencyTarget] == "undefined")
             throw new Error("Invalid target: " + dependencyTarget);
-    }
-    
+        }
+
     var pbxTargetDependency = 'PBXTargetDependency',
         pbxContainerItemProxy = 'PBXContainerItemProxy',
         pbxTargetDependencySection = this.hash.project.objects[pbxTargetDependency],
@@ -506,32 +544,32 @@ pbxProject.prototype.addTargetDependency = function (target, dependencyTargets) 
             targetDependencyCommentKey = f("%s_comment", targetDependencyUuid),
             itemProxyUuid = this.generateUuid(),
             itemProxyCommentKey = f("%s_comment", itemProxyUuid),
-            itemProxy =  {
+            itemProxy = {
                 isa: pbxContainerItemProxy,
                 containerPortal: this.hash.project['rootObject'],
                 containerPortal_comment: this.hash.project['rootObject_comment'],
                 proxyType: 1,
                 remoteGlobalIDString: dependencyTargetUuid,
-                remoteInfo: nativeTargets[dependencyTargetUuid].name 
+                remoteInfo: nativeTargets[dependencyTargetUuid].name
             },
             targetDependency = {
                 isa: pbxTargetDependency,
-                target: dependencyTargetUuid, 
+                target: dependencyTargetUuid,
                 target_comment: nativeTargets[dependencyTargetCommentKey],
                 targetProxy: itemProxyUuid,
                 targetProxy_comment: pbxContainerItemProxy
             };
-            
+
         if (pbxContainerItemProxySection && pbxTargetDependencySection) {
             pbxContainerItemProxySection[itemProxyUuid] = itemProxy;
             pbxContainerItemProxySection[itemProxyCommentKey] = pbxContainerItemProxy;
             pbxTargetDependencySection[targetDependencyUuid] = targetDependency;
             pbxTargetDependencySection[targetDependencyCommentKey] = pbxTargetDependency;
-            nativeTargets[target].dependencies.push({value: targetDependencyUuid, comment: pbxTargetDependency})
+            nativeTargets[target].dependencies.push({ value: targetDependencyUuid, comment: pbxTargetDependency })
         }
     }
-    
-    return {uuid: target, target: nativeTargets[target]};
+
+    return { uuid: target, target: nativeTargets[target] };
 }
 
 pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
@@ -547,20 +585,20 @@ pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
             runOnlyForDeploymentPostprocessing: 0
         },
         filePathToBuildFile = {};
-    
+
     for (var key in buildFileSection) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
-        
+
         var buildFileKey = key.split(COMMENT_KEY)[0],
             buildFile = buildFileSection[buildFileKey];
-            fileReference = fileReferenceSection[buildFile.fileRef];
+        fileReference = fileReferenceSection[buildFile.fileRef];
 
         if (!fileReference) continue;
 
         var pbxFileObj = new pbxFile(fileReference.path);
-        
-        filePathToBuildFile[fileReference.path] = {uuid: buildFileKey, basename: pbxFileObj.basename, group: pbxFileObj.group};
+
+        filePathToBuildFile[fileReference.path] = { uuid: buildFileKey, basename: pbxFileObj.basename, group: pbxFileObj.group };
     }
 
     for (var index = 0; index < filePathsArray.length; index++) {
@@ -575,35 +613,35 @@ pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
             buildPhase.files.push(pbxBuildPhaseObj(filePathToBuildFile[filePathQuoted]));
             continue;
         }
-        
+
         file.uuid = this.generateUuid();
         file.fileRef = this.generateUuid();
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
         this.addToPbxBuildFileSection(file);        // PBXBuildFile
         buildPhase.files.push(pbxBuildPhaseObj(file));
     }
-    
+
     if (section) {
         section[buildPhaseUuid] = buildPhase;
         section[commentKey] = comment;
     }
-    
-    return {uuid: buildPhaseUuid, buildPhase: buildPhase};
+
+    return { uuid: buildPhaseUuid, buildPhase: buildPhase };
 }
 
 // helper access functions
-pbxProject.prototype.pbxProjectSection = function () {
+pbxProject.prototype.pbxProjectSection = function() {
     return this.hash.project.objects['PBXProject'];
 }
-pbxProject.prototype.pbxBuildFileSection = function () {
+pbxProject.prototype.pbxBuildFileSection = function() {
     return this.hash.project.objects['PBXBuildFile'];
 }
 
-pbxProject.prototype.pbxXCBuildConfigurationSection = function () {
+pbxProject.prototype.pbxXCBuildConfigurationSection = function() {
     return this.hash.project.objects['XCBuildConfiguration'];
 }
 
-pbxProject.prototype.pbxFileReferenceSection = function () {
+pbxProject.prototype.pbxFileReferenceSection = function() {
     return this.hash.project.objects['PBXFileReference'];
 }
 
@@ -611,19 +649,19 @@ pbxProject.prototype.pbxNativeTarget = function () {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
-pbxProject.prototype.pbxXCConfigurationList = function () {
+pbxProject.prototype.pbxXCConfigurationList = function() {
     return this.hash.project.objects['XCConfigurationList'];
 }
 
-pbxProject.prototype.pbxGroupByName = function (name) {
-    return this.pbxItemByComment(name, 'PBXGroup');    
+pbxProject.prototype.pbxGroupByName = function(name) {
+    return this.pbxItemByComment(name, 'PBXGroup');
 }
 
-pbxProject.prototype.pbxTargetByName = function (name) {
+pbxProject.prototype.pbxTargetByName = function(name) {
     return this.pbxItemByComment(name, 'PBXNativeTarget');
 }
 
-pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
+pbxProject.prototype.pbxItemByComment = function(name, pbxSectionName) {
     var section = this.hash.project.objects[pbxSectionName],
         key, itemKey;
 
@@ -640,56 +678,56 @@ pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
     return null;
 }
 
-pbxProject.prototype.pbxSourcesBuildPhaseObj = function (target) {
+pbxProject.prototype.pbxSourcesBuildPhaseObj = function(target) {
     return this.buildPhaseObject('PBXSourcesBuildPhase', 'Sources', target);
 }
 
-pbxProject.prototype.pbxResourcesBuildPhaseObj = function (target) {
-    return this.buildPhaseObject('PBXResourcesBuildPhase', 'Resources',target);
+pbxProject.prototype.pbxResourcesBuildPhaseObj = function(target) {
+    return this.buildPhaseObject('PBXResourcesBuildPhase', 'Resources', target);
 }
 
-pbxProject.prototype.pbxFrameworksBuildPhaseObj = function (target) {
-    return this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks',target);
+pbxProject.prototype.pbxFrameworksBuildPhaseObj = function(target) {
+    return this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks', target);
 }
 
 // Find Build Phase from group/target
-pbxProject.prototype.buildPhase = function (group,target) {
+pbxProject.prototype.buildPhase = function(group, target) {
 
     if (!target)
         return undefined;
 
      var nativeTargets = this.pbxNativeTarget();
      if (typeof nativeTargets[target] == "undefined")
-        throw new Error("Invalid target: "+target);
+        throw new Error("Invalid target: " + target);
 
-     var nativeTarget= nativeTargets[target];
-     var buildPhases = nativeTarget.buildPhases;
+    var nativeTarget = nativeTargets[target];
+    var buildPhases = nativeTarget.buildPhases;
      for(var i in buildPhases)
      {
         var buildPhase = buildPhases[i];
         if (buildPhase.comment==group)
-            return buildPhase.value+"_comment";
-     } 
-}
+            return buildPhase.value + "_comment";
+        }
+    }
 
-pbxProject.prototype.buildPhaseObject = function (name, group,target) {
+pbxProject.prototype.buildPhaseObject = function(name, group, target) {
     var section = this.hash.project.objects[name],
         obj, sectionKey, key;
-    var buildPhase = this.buildPhase(group,target);
+    var buildPhase = this.buildPhase(group, target);
 
     for (key in section) {
 
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
-  
+
         // select the proper buildPhase
         if (buildPhase && buildPhase!=key)
             continue;
         if (section[key] == group) {
-            sectionKey = key.split(COMMENT_KEY)[0];  
+            sectionKey = key.split(COMMENT_KEY)[0];
             return section[sectionKey];
         }
-     }
+    }
     return null;
 }
 
@@ -703,7 +741,7 @@ pbxProject.prototype.updateProductName = function(name) {
     this.updateBuildProperty('PRODUCT_NAME', '"' + name + '"');
 }
 
-pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
+pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'FRAMEWORK_SEARCH_PATHS',
@@ -731,7 +769,7 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
     }
 }
 
-pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
+pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -743,7 +781,7 @@ pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
             continue;
 
         if (!buildSettings['FRAMEWORK_SEARCH_PATHS']
-                || buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED) {
+            || buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED) {
             buildSettings['FRAMEWORK_SEARCH_PATHS'] = [INHERITED];
         }
 
@@ -751,7 +789,7 @@ pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
     }
 }
 
-pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
+pbxProject.prototype.removeFromLibrarySearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'LIBRARY_SEARCH_PATHS',
@@ -779,7 +817,7 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
     }
 }
 
-pbxProject.prototype.addToLibrarySearchPaths = function (file) {
+pbxProject.prototype.addToLibrarySearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -791,7 +829,7 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
             continue;
 
         if (!buildSettings['LIBRARY_SEARCH_PATHS']
-                || buildSettings['LIBRARY_SEARCH_PATHS'] === INHERITED) {
+            || buildSettings['LIBRARY_SEARCH_PATHS'] === INHERITED) {
             buildSettings['LIBRARY_SEARCH_PATHS'] = [INHERITED];
         }
 
@@ -803,7 +841,7 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
     }
 }
 
-pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
+pbxProject.prototype.removeFromHeaderSearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'HEADER_SEARCH_PATHS',
@@ -828,7 +866,7 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
 
     }
 }
-pbxProject.prototype.addToHeaderSearchPaths = function (file) {
+pbxProject.prototype.addToHeaderSearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -851,7 +889,7 @@ pbxProject.prototype.addToHeaderSearchPaths = function (file) {
     }
 }
 // a JS getter. hmmm
-pbxProject.prototype.__defineGetter__("productName", function () {
+pbxProject.prototype.__defineGetter__("productName", function() {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         config, productName;
 
@@ -865,7 +903,7 @@ pbxProject.prototype.__defineGetter__("productName", function () {
 });
 
 // check if file is present
-pbxProject.prototype.hasFile = function (filePath) {
+pbxProject.prototype.hasFile = function(filePath) {
     var files = nonComments(this.pbxFileReferenceSection()),
         file, id;
     for (id in files) {
@@ -909,18 +947,18 @@ function pbxFileReferenceObj(file) {
 
     obj.isa = 'PBXFileReference';
     obj.lastKnownFileType = file.lastType;
-    
+
     obj.name = "\"" + file.basename + "\"";
-    obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
-    
+        obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
+
     obj.sourceTree = file.sourceTree;
 
     if (file.fileEncoding)
         obj.fileEncoding = file.fileEncoding;
-        
+
     if (file.explicitFileType)
         obj.explicitFileType = file.explicitFileType;
-        
+
     if ('includeInIndex' in file)
         obj.includeInIndex = file.includeInIndex;
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -591,7 +591,7 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     if (!target)
         return undefined;
 
-    var nativeTargets = this.pbxNativeTarget();
+    var nativeTargets = this.pbxNativeTargetSection();
 
     if (typeof nativeTargets[target] == "undefined")
         throw new Error("Invalid target: " + target);

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -345,6 +345,16 @@ pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTr
     return { uuid: pbxGroupUuid, pbxGroup: pbxGroup };
 }
 
+pbxProject.prototype.addToPbxProjectSection = function(target) {
+
+    var newTarget = {
+            value: target.pbxNativeTarget,
+            comment: pbxNativeTargetComment(target.pbxNativeTarget)
+        };
+
+    this.pbxProjectSection()[this.getFirstProject()['uuid']]['targets'].push(newTarget);
+}
+
 pbxProject.prototype.addToPbxFileReferenceSection = function(file) {
     var commentKey = f("%s_comment", file.fileRef);
 
@@ -989,6 +999,10 @@ function pbxBuildFileComment(file) {
 
 function pbxFileReferenceComment(file) {
     return file.basename;
+}
+
+function pbxNativeTargetComment(target) {
+    return target.name;
 }
 
 function longComment(file) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -401,7 +401,7 @@ pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTr
 pbxProject.prototype.addToPbxProjectSection = function(target) {
 
     var newTarget = {
-            value: target.pbxNativeTarget,
+            value: target.uuid,
             comment: pbxNativeTargetComment(target.pbxNativeTarget)
         };
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1165,6 +1165,24 @@ function unquote(str) {
     if (str) return str.replace(/^"(.*)"$/, "$1");
 }
 
+function producttypeForTargettype (targetType) {
+
+    PRODUCTTYPE_BY_TARGETTYPE = {
+            application: 'com.apple.product-type.application',
+            app_extension: 'com.apple.product-type.app-extension',
+            bundle: 'com.apple.product-type.bundle',
+            command_line_tool: 'com.apple.product-type.tool',
+            dynamic_library: 'com.apple.product-type.library.dynamic',
+            framework: 'com.apple.product-type.framework',
+            static_library: 'com.apple.product-type.library.static',
+            unit_test_bundle: 'com.apple.product-type.bundle.unit-test',
+            watch_app: 'com.apple.product-type.application.watchapp',
+            watch_extension: 'com.apple.product-type.watchkit-extension'
+        };
+
+    return PRODUCTTYPE_BY_TARGETTYPE[targetType]
+}
+
 pbxProject.prototype.getFirstProject = function() {
 
     // Get pbxProject container

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -218,6 +218,7 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
     file.fileRef = this.generateUuid();
     file.target = opt ? opt.target : undefined;
 
+    if (this.hasFile(file.path)) return false;
 
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxFileReferenceSection(file);    // PBXFileReference
@@ -1012,15 +1013,24 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
     // Setup uuid and name of new target
     var targetUuid = this.generateUuid(),
         targetType = type,
-        targetSubfolder = subfolder,
+        targetSubfolder = subfolder || name,
         targetName = name.trim();
+        
+    // Check type against list of allowed target types
+    if (!targetName) {
+        throw new Error("Target name missing.");
+    }    
+
+    // Check type against list of allowed target types
+    if (!targetType) {
+        throw new Error("Target type missing.");
+    } 
 
     // Check type against list of allowed target types
     if (!producttypeForTargettype(targetType)) {
-        console.error ('Invalid target type: ' + targetType);
-        return false
+        throw new Error("Target type invalid: " + targetType);
     }
-
+    
     // Build Configuration: Create
     var buildConfigurationsList = [
         {
@@ -1131,31 +1141,18 @@ function pbxBuildFileObj(file) {
 }
 
 function pbxFileReferenceObj(file) {
-    var obj = Object.create(null);
+    var fileObject = {
+        isa: "PBXFileReference",
+        name: "\"" + file.basename + "\"",
+        path: "\"" + file.path.replace(/\\/g, '/') + "\"",
+        sourceTree: file.sourceTree,
+        fileEncoding: file.fileEncoding,
+        lastKnownFileType: file.lastKnownFileType,
+        explicitFileType: file.explicitFileType,
+        includeInIndex: file.includeInIndex
+    };
 
-    obj.isa = 'PBXFileReference';
-
-    obj.name = "\"" + file.basename + "\"";
-
-    if (file.path) {
-        obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
-    }
-
-    obj.sourceTree = file.sourceTree;
-
-    if (file.fileEncoding)
-        obj.fileEncoding = file.fileEncoding;
-
-    if (file.lastKnownFileType)
-        obj.lastKnownFileType = file.lastKnownFileType;
-
-    if (file.explicitFileType)
-        obj.explicitFileType = file.explicitFileType;
-
-    if (file.includeInIndex)
-        obj.includeInIndex = file.includeInIndex;
-
-    return obj;
+    return fileObject;
 }
 
 function pbxGroupChild(file) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -933,6 +933,93 @@ pbxProject.prototype.hasFile = function(filePath) {
     return false;
 }
 
+pbxProject.prototype.addTarget = function(name, type) {
+
+    // Setup uuid and name of new target
+    var targetUuid = this.generateUuid(),
+        targetType = type,
+        targetName = name.trim();
+
+    // Check type against list of allowed target types
+    if (!producttypeForTargettype(targetType)) {
+        console.error ('Invalid target type: ' + targetType);
+        return false
+    }
+
+    // Build Configuration: Create
+    var buildConfigurationsList = [
+        {
+            name: 'Debug',
+            isa: 'XCBuildConfiguration',
+            buildSettings: {
+                GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
+                INFOPLIST_FILE: targetName + '-Info.Plist',
+                LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+                PRODUCT_NAME: targetName,
+                SKIP_INSTALL: 'YES'
+            }
+        },
+        {
+            name: 'Release',
+            isa: 'XCBuildConfiguration',
+            buildSettings: {
+                INFOPLIST_FILE: targetName + '-Info.Plist',
+                LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+                PRODUCT_NAME: targetName,
+                SKIP_INSTALL: 'YES'
+            }
+        }
+    ];
+
+    // Build Configuration: Add
+    var buildConfigurations = this.addXCConfigurationList(buildConfigurationsList, 'Release', 'Build configuration list for PBXNativeTarget "' + targetName +'"'),
+        buildConfigurationsUuid = buildConfigurations.uuid;
+
+    // Product: Create
+    var productName = targetName,
+        productType = producttypeForTargettype(targetType),
+        productFile = this.addProductFile(productName, { 'explicitFileType': productType }),
+        productFileName = productFile.basename;
+
+    // Product: Embed in first target (only for "extension"-type targets)
+    if (targetType === 'app_extension') {
+        var embedPhase;
+        var embedFile;
+
+        // TODO: Add embedding via "PBXCopyFilesBuildPhase" build phase
+    };
+
+    // Target: Create
+    var target = {
+            uuid: targetUuid,
+            pbxNativeTarget: {
+                isa: 'PBXNativeTarget',
+                name: targetName,
+                productName: targetName,
+                productReference: productFile.fileRef,
+                productType: '"' + producttypeForTargettype(targetType) + '"',
+                buildConfigurationList: buildConfigurationsUuid,
+                buildPhases: [],
+                buildRules: [],
+                dependencies: []
+            }
+    };
+
+    // Target: Add to PBXNativeTarget section
+    this.addToPbxNativeTargetSection(target)
+
+    // Target: Add uuid to root project
+    this.addToPbxProjectSection(target);
+
+    // Target: Add dependency for this target to first (main) target
+    this.addTargetDependency(this.getFirstTarget().uuid, [target.uuid]);
+
+
+    // Return target on success
+    return target;
+
+};
+
 // helper recursive prop search+replace
 function propReplace(obj, prop, value) {
     var o = {};

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -973,10 +973,13 @@ function pbxFileReferenceObj(file) {
     if (file.fileEncoding)
         obj.fileEncoding = file.fileEncoding;
 
+    if (file.lastKnownFileType)
+        obj.lastKnownFileType = file.lastKnownFileType;
+
     if (file.explicitFileType)
         obj.explicitFileType = file.explicitFileType;
 
-    if ('includeInIndex' in file)
+    if (file.includeInIndex)
         obj.includeInIndex = file.includeInIndex;
 
     return obj;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1057,18 +1057,8 @@ pbxProject.prototype.addTarget = function(name, type) {
     var productName = targetName,
         productType = producttypeForTargettype(targetType),
         productFileType = filetypeForProducttype(productType),
-        productFile = this.addProductFile(productName, { 'target': targetUuid, 'group': 'CopyFiles' }),
+        productFile = this.addProductFile(productName, { 'target': targetUuid,  'explicitFileType': productFileType}),
         productFileName = productFile.basename;
-
-    // Product: Embed (only for "extension"-type targets)
-    if (targetType === 'app_extension') {
-
-        // Create "Copy Files" build phase for target which contains the extension
-        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'CopyFiles', this.getFirstTarget().uuid)
-
-        // Add product reference to "Copy Files" build phase
-        this.addCopyfile(productFileName, { 'explicitFileType': productFileType, 'target': this.getFirstTarget().uuid })
-    };
 
     // Target: Create
     var target = {
@@ -1088,6 +1078,14 @@ pbxProject.prototype.addTarget = function(name, type) {
 
     // Target: Add to PBXNativeTarget section
     this.addToPbxNativeTargetSection(target)
+
+    // Product: Embed (only for "extension"-type targets)
+    if (targetType === 'app_extension') {
+        // Create "Copy Files" build phase for target which contains the extension
+        this.addToPbxBuildFileSection(productFile);
+        var newPhase = this.addBuildPhase([productFileName], 'PBXCopyFilesBuildPhase', 'Copy Files', targetType)
+        this.addBuildPhaseToTarget(newPhase.buildPhase, this.getFirstTarget().uuid)
+    };
 
     // Target: Add uuid to root project
     this.addToPbxProjectSection(target);

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1095,7 +1095,7 @@ function pbxBuildFileComment(file) {
 }
 
 function pbxFileReferenceComment(file) {
-    return file.basename;
+    return path.basename(file.path);
 }
 
 function pbxNativeTargetComment(target) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1053,7 +1053,10 @@ function pbxFileReferenceObj(file) {
     obj.lastKnownFileType = file.lastType;
 
     obj.name = "\"" + file.basename + "\"";
+
+    if (file.path) {
         obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
+    }
 
     obj.sourceTree = file.sourceTree;
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1282,6 +1282,19 @@ function unquote(str) {
     if (str) return str.replace(/^"(.*)"$/, "$1");
 }
 
+
+function buildPhaseNameForIsa (isa) {
+
+    BUILDPHASENAME_BY_ISA = {
+        PBXCopyFilesBuildPhase: 'Copy Files',
+        PBXResourcesBuildPhase: 'Resources',
+        PBXSourcesBuildPhase: 'Sources',
+        PBXFrameworksBuildPhase: 'Frameworks'
+    }
+
+    return BUILDPHASENAME_BY_ISA[isa]
+}
+
 function producttypeForTargettype (targetType) {
 
     PRODUCTTYPE_BY_TARGETTYPE = {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1016,4 +1016,35 @@ function unquote(str) {
     if (str) return str.replace(/^"(.*)"$/, "$1");
 }
 
+pbxProject.prototype.getFirstProject = function() {
+
+    // Get pbxProject container
+    var pbxProjectContainer = this.pbxProjectSection();
+
+    // Get first pbxProject UUID
+    var firstProjectUuid = Object.keys(pbxProjectContainer)[0];
+
+    // Get first pbxProject
+    var firstProject = pbxProjectContainer[firstProjectUuid];
+
+     return {
+        uuid: firstProjectUuid,
+        firstProject: firstProject
+    }
+}
+
+pbxProject.prototype.getFirstTarget = function() {
+
+    // Get first targets UUID
+    var firstTargetUuid = this.getFirstProject()['firstProject']['targets'][0].value;
+
+    // Get first pbxNativeTarget
+    var firstTarget = this.pbxNativeTargetSection()[firstTargetUuid];
+
+    return {
+        uuid: firstTargetUuid,
+        firstTarget: firstTarget
+    }
+}
+
 module.exports = pbxProject;

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -81,7 +81,7 @@ exports.addFramework = {
             fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
-        test.equal(fileRefEntry.lastKnownFileType, '"compiled.mach-o.dylib"');
+        test.equal(fileRefEntry.lastKnownFileType, 'compiled.mach-o.dylib');
         test.equal(fileRefEntry.name, '"libsqlite3.dylib"');
         test.equal(fileRefEntry.path, '"usr/lib/libsqlite3.dylib"');
         test.equal(fileRefEntry.sourceTree, 'SDKROOT');

--- a/test/addResourceFile.js
+++ b/test/addResourceFile.js
@@ -90,7 +90,7 @@ exports.addResourceFile = {
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, undefined);
-        test.equal(fileRefEntry.lastKnownFileType, '"wrapper.plug-in"');
+        test.equal(fileRefEntry.lastKnownFileType, 'wrapper.plug-in');
         test.equal(fileRefEntry.name, '"assets.bundle"');
         test.equal(fileRefEntry.path, '"Resources/assets.bundle"');
         test.equal(fileRefEntry.sourceTree, '"<group>"');
@@ -151,7 +151,7 @@ exports.addResourceFile = {
                             
             test.equal(fileRefEntry.isa, 'PBXFileReference');
             test.equal(fileRefEntry.fileEncoding, undefined);
-            test.equal(fileRefEntry.lastKnownFileType, '"wrapper.plug-in"');
+            test.equal(fileRefEntry.lastKnownFileType, 'wrapper.plug-in');
             test.equal(fileRefEntry.name, '"assets.bundle"');
             test.equal(fileRefEntry.path, '"Plugins/assets.bundle"');
             test.equal(fileRefEntry.sourceTree, '"<group>"');

--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -1,0 +1,89 @@
+var fullProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(fullProject),
+    pbx = require('../lib/pbxProject'),
+    proj = new pbx('.');
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+var TARGET_NAME = 'TestExtension',
+    TARGET_TYPE = 'app_extension',
+    TARGET_SUBFOLDER_NAME = 'TestExtensionFiles';
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+exports.addTarget = {
+    'should throw when target name is missing': function (test) {
+        test.throws(function() {
+            proj.addTarget(null, TARGET_TYPE);
+        });
+        
+        test.done();
+    },
+    'should throw when target type missing': function (test) {
+        test.throws(function() {
+            proj.addTarget(TARGET_NAME, null);
+        });
+        
+        test.done();
+    },
+    'should create a new target': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME);
+        
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+                
+        test.done();
+    },
+    'should create a new target and add source, framework, resource and header files and the corresponding build phases': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME),
+            options = { 'target' : target.uuid };
+   
+        var sourceFile = proj.addSourceFile('Plugins/file.m', options),
+            sourcePhase = proj.addBuildPhase([], 'PBXSourcesBuildPhase', 'Sources', target.uuid),
+            resourceFile = proj.addResourceFile('assets.bundle', options),
+            resourcePhase = proj.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', target.uuid),
+            frameworkFile = proj.addFramework('libsqlite3.dylib', options);
+            frameworkPhase = proj.addBuildPhase([], 'PBXFrameworkBuildPhase', 'Frameworks', target.uuid),
+            headerFile = proj.addHeaderFile('file.h', options);
+        
+        test.ok(sourcePhase);
+        test.ok(resourcePhase);
+        test.ok(frameworkPhase);
+          
+        test.equal(sourceFile.constructor, pbxFile);
+        test.equal(resourceFile.constructor, pbxFile);
+        test.equal(frameworkFile.constructor, pbxFile);
+        test.equal(headerFile.constructor, pbxFile);
+        
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+    
+        test.done();
+        
+    }   
+}

--- a/test/addTargetDependency.js
+++ b/test/addTargetDependency.js
@@ -40,7 +40,7 @@ exports.addTargetDependency = {
         test.done();
     },
     'should add targetDependencies to target': function (test) {
-        var targetInPbxProj = proj.pbxNativeTarget()['1D6058900D05DD3D006BFB55'];
+        var targetInPbxProj = proj.pbxNativeTargetSection()['1D6058900D05DD3D006BFB55'];
         test.deepEqual(targetInPbxProj.dependencies, []);
         
         var target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target;

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -1,67 +1,67 @@
 var pbxFile = require('../lib/pbxFile');
 
-exports['lastType'] = {
+exports['lastKnownFileType'] = {
     'should detect that a .m path means sourcecode.c.objc': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
-        test.equal('sourcecode.c.objc', sourceFile.lastType);
+        test.equal('sourcecode.c.objc', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .h path means sourceFile.c.h': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.h');
 
-        test.equal('sourcecode.c.h', sourceFile.lastType);
+        test.equal('sourcecode.c.h', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .bundle path means "wrapper.plug-in"': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.bundle');
 
-        test.equal('"wrapper.plug-in"', sourceFile.lastType);
+        test.equal('wrapper.plug-in', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .xib path means file.xib': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.xib');
 
-        test.equal('file.xib', sourceFile.lastType);
+        test.equal('file.xib', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .dylib path means "compiled.mach-o.dylib"': function (test) {
         var sourceFile = new pbxFile('libsqlite3.dylib');
 
-        test.equal('"compiled.mach-o.dylib"', sourceFile.lastType);
+        test.equal('compiled.mach-o.dylib', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .framework path means wrapper.framework': function (test) {
         var sourceFile = new pbxFile('MessageUI.framework');
 
-        test.equal('wrapper.framework', sourceFile.lastType);
+        test.equal('wrapper.framework', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .a path means archive.ar': function (test) {
         var sourceFile = new pbxFile('libGoogleAnalytics.a');
 
-        test.equal('archive.ar', sourceFile.lastType);
+        test.equal('archive.ar', sourceFile.lastKnownFileType);
         test.done();
     },
 
-    'should allow lastType to be overridden': function (test) {
+    'should allow lastKnownFileType to be overridden': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m',
-                { lastType: 'somestupidtype' });
+                { lastKnownFileType: 'somestupidtype' });
 
-        test.equal('somestupidtype', sourceFile.lastType);
+        test.equal('somestupidtype', sourceFile.lastKnownFileType);
         test.done();
     },
 
-    'should set lastType to unknown if undetectable': function (test) {
+    'should set lastKnownFileType to unknown if undetectable': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.guh');
 
-        test.equal('unknown', sourceFile.lastType);
+        test.equal('unknown', sourceFile.lastKnownFileType);
         test.done();
     }
 }

--- a/test/removeResourceFile.js
+++ b/test/removeResourceFile.js
@@ -140,7 +140,7 @@ exports.removeResourceFile = {
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, undefined);
-        test.equal(fileRefEntry.lastKnownFileType, '"wrapper.plug-in"');
+        test.equal(fileRefEntry.lastKnownFileType, 'wrapper.plug-in');
         test.equal(fileRefEntry.name, '"assets.bundle"');
         test.equal(fileRefEntry.path, '"Resources/assets.bundle"');
         test.equal(fileRefEntry.sourceTree, '"<group>"');


### PR DESCRIPTION
**In an arduous undertaking, i completed a nodejs implementation of [Ruby xcodeprojs](http://www.rubydoc.info/gems/xcodeproj/Xcodeproj) 'addTarget' as a feature for node_xcode.**

Motivation:
In context of state-of-the-art, high-end Cordova applications for iOS, iOS app extensions might be becoming an increasingly critical part of the iOS app tech stack. However, there is no vector to integrate these using standard **Cordova** interfaces (e.g. plugman, the CLI, etc.) or related venues of automation.

For example, adding a **Apple Watchkit Extension** requires interaction with the XCode UI to add all corresponding WatchKit extensions, build phases and targets. Or incorporating a "Share" extension within a Cordova application (or developing an extension that leverages Cordova in some way) would require projects to break existing automation solutions or to resolve to hacks like diffed XCode project files, or worse.

My solution should allow for seamless integration of iOS extensions within Cordova or Ionic projects, or for the development of Widgets, Extensions using Cordova. Within plugin development, this can now easily be done e.g. with Cordova plugin installation hook. I'll publish a implementation example for this shortly.

The solution was to build a simple node_xcode style interface for adding **pbxNativeTargets**, building on the existing node-xcode API - which is stellar, but definitely requires refactoring. Great thanks to @Mitko-Kerezov, who seemed to have worked within similar aspects of the codebase and whose recent contributions i built my solution upon.

I implemented the steps required and also refactored stuff in several areas (please reference the 'atomic' commits within the [add_target](https://github.com/SidneyS/node-xcode/tree/add_target) branch of my node_xcode fork). During the course of this effort, substantial amounts of the **pbxFile** prototype had to be rewritten to support scenarios with current XCode capabilities (e.g., up-to-date extension types) within the application projects managed by node_xcode.

Also, i added the capability to deal with artifacts created during build-time has been added.

Of course, i added tests for all new stuff and made minor required adaptations to the existing ones. I made sure that all of the now over 1000 tests succeed - which is the case.

I'm looking forward to your thoughts and would be very happy if we could merge this into mainline node_xcode.

Kind regards,
Sidney / Berlin, Germany