### PR TITLE
Enhance removeFromHeaderSearchPaths function

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -559,7 +559,13 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'HEADER_SEARCH_PATHS',
         config, buildSettings, searchPaths;
-    var new_path = searchPathForFile(file, this);
+    
+    var new_path;
+    if (typeof file === 'string') {
+        new_path = file;
+    } else {
+        new_path = searchPathForFile(file, this);
+    }
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;


### PR DESCRIPTION
The function `addToHeaderSearchPaths` allows usage of arguments of type `string`. 
Implement this behavior in `removeFromHeaderSearchPaths `.