### PR TITLE
Don't force async parsing worker to exit.

### DIFF
--- a/lib/parseJob.js
+++ b/lib/parseJob.js
@@ -6,11 +6,10 @@ var fs = require('fs'),
     fileContents, obj;
 
 try {
-    fileContents = fs.readFileSync(path, 'utf-8'),
-    obj = parser.parse(fileContents)
-    process.send(obj)
-    process.exit()
+    fileContents = fs.readFileSync(path, 'utf-8');
+    obj = parser.parse(fileContents);
+    process.send(obj);
 } catch (e) {
-    process.send(e)
-    process.exit(1)
+    process.send(e);
+    process.exitCode = 1;
 }


### PR DESCRIPTION
This fixes the issue, caused by changed `process.send` behaviour (which became async at one time, so `process.exit` terminates worker before the message will be sent completely).

This resolves #61