### PR TITLE
Core Data files support (adding)

### DIFF
--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -94,8 +94,13 @@ function defaultEncoding(fileRef) {
 }
 
 function detectGroup(fileRef) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
+    var extension = path.extname(this.basename).substring(1),
+        filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
+
+    if (extension === 'xcdatamodeld') {
+        return 'Sources';
+    }
 
     if (!groupName) {
         return DEFAULT_GROUP;

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -94,7 +94,7 @@ function defaultEncoding(fileRef) {
 }
 
 function detectGroup(fileRef) {
-    var extension = path.extname(this.basename).substring(1),
+    var extension = path.extname(fileRef.basename).substring(1),
         filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
 
@@ -159,6 +159,7 @@ function pbxFile(filepath, opt) {
     
     self = this;
 
+    this.basename = path.basename(filepath);
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
     this.group = detectGroup(self);
 
@@ -168,7 +169,6 @@ function pbxFile(filepath, opt) {
         this.dirname = path.dirname(filepath);
     }
 
-    this.basename = path.basename(filepath);
     this.path = defaultPath(this, filepath);
     this.fileEncoding = this.defaultEncoding = opt.defaultEncoding || defaultEncoding(self);
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -8,6 +8,7 @@ var util = require('util'),
     pbxFile = require('./pbxFile'),
     fs = require('fs'),
     parser = require('./parser/pbxproj'),
+    plist = require('simple-plist'),
     COMMENT_KEY = /_comment$/
 
 function pbxProject(filename) {
@@ -507,6 +508,26 @@ pbxProject.prototype.removeFromPbxFileReferenceSection = function(file) {
     return file;
 }
 
+pbxProject.prototype.addToXcVersionGroupSection = function(file) {
+    if (!file.models || !file.currentModel) {
+        throw new Error("Cannot create a XCVersionGroup section from not a data model document file");
+    }
+
+    var commentKey = f("%s_comment", file.fileRef);
+
+    if (!this.xcVersionGroupSection()[file.fileRef]) {
+        this.xcVersionGroupSection()[file.fileRef] = {
+            isa: 'XCVersionGroup',
+            children: file.models.map(function (el) { return el.fileRef; }),
+            currentVersion: file.currentModel.fileRef,
+            path: file.path,
+            sourceTree: '"<group>"',
+            versionGroupType: 'wrapper.xcdatamodel'
+        };
+        this.xcVersionGroupSection()[commentKey] = path.basename(file.path);
+    }
+}
+
 pbxProject.prototype.addToPluginsPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Plugins');
     pluginsGroup.children.push(pbxGroupChild(file));
@@ -805,7 +826,7 @@ pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
-pbxProject.prototype.pbxVersionGroupSection = function () {
+pbxProject.prototype.xcVersionGroupSection = function () {
     if (typeof this.hash.project.objects['XCVersionGroup'] !== 'object') {
         this.hash.project.objects['XCVersionGroup'] = {};
     }
@@ -836,6 +857,22 @@ pbxProject.prototype.pbxGroupByName = function(name) {
 
 pbxProject.prototype.pbxTargetByName = function(name) {
     return this.pbxItemByComment(name, 'PBXNativeTarget');
+}
+
+pbxProject.prototype.findTargetKey = function(name) {
+    var targets = this.hash.project.objects['PBXNativeTarget'];
+
+    for (var key in targets) {
+        // only look for comments
+        if (COMMENT_KEY.test(key)) continue;
+
+        var target = targets[key];
+        if (target.name === name) {
+            return key;
+        }
+    }
+
+    return null;
 }
 
 pbxProject.prototype.pbxItemByComment = function(name, pbxSectionName) {
@@ -1710,6 +1747,62 @@ pbxProject.prototype.getBuildConfigByName = function(name) {
         }
     }
     return target;
+}
+
+pbxProject.prototype.addDataModelDocument = function(filePath, group, opt) {
+    if (!group) {
+        group = 'Resources';
+    }
+    if (!this.getPBXGroupByKey(group)) {
+        group = this.findPBXGroupKey({ name: group });
+    }
+
+    var file = new pbxFile(filePath, opt);
+
+    if (!file || this.hasFile(file.path)) return null;
+
+    file.fileRef = this.generateUuid();
+    this.addToPbxGroup(file, group);
+
+    if (!file) return false;
+
+    file.target = opt ? opt.target : undefined;
+    file.uuid = this.generateUuid();
+
+    this.addToPbxBuildFileSection(file);
+    this.addToPbxSourcesBuildPhase(file);
+
+    file.models = [];
+    var currentVersionName;
+    var modelFiles = fs.readdirSync(file.path);
+    for (var index in modelFiles) {
+        var modelFileName = modelFiles[index];
+        var modelFilePath = path.join(filePath, modelFileName);
+
+        if (modelFileName == '.xccurrentversion') {
+            currentVersionName = plist.readFileSync(modelFilePath)._XCCurrentVersionName;
+            continue;
+        }
+
+        var modelFile = new pbxFile(modelFilePath);
+        modelFile.fileRef = this.generateUuid();
+
+        this.addToPbxFileReferenceSection(modelFile);
+
+        file.models.push(modelFile);
+
+        if (currentVersionName && currentVersionName === modelFileName) {
+            file.currentModel = modelFile;
+        }
+    }
+
+    if (!file.currentModel) {
+        file.currentModel = file.models[0];
+    }
+
+    this.addToXcVersionGroupSection(file);
+
+    return file;
 }
 
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -805,6 +805,14 @@ pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
+pbxProject.prototype.pbxVersionGroupSection = function () {
+    if (typeof this.hash.project.objects['XCVersionGroup'] !== 'object') {
+        this.hash.project.objects['XCVersionGroup'] = {};
+    }
+
+    return this.hash.project.objects['XCVersionGroup'];
+}
+
 pbxProject.prototype.pbxXCConfigurationList = function() {
     return this.hash.project.objects['XCConfigurationList'];
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -520,6 +520,7 @@ pbxProject.prototype.addToXcVersionGroupSection = function(file) {
             isa: 'XCVersionGroup',
             children: file.models.map(function (el) { return el.fileRef; }),
             currentVersion: file.currentModel.fileRef,
+            name: path.basename(file.path),
             path: file.path,
             sourceTree: '"<group>"',
             versionGroupType: 'wrapper.xcdatamodel'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
   "version": "0.8.2",
-  "main":"index.js",
+  "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"
   },
@@ -11,8 +11,9 @@
     "node": ">=0.6.7"
   },
   "dependencies": {
+    "node-uuid":"1.3.3",
     "pegjs":"0.6.2",
-    "node-uuid":"1.3.3"
+    "simple-plist": "0.0.4"
   },
   "devDependencies": {
     "nodeunit":"0.9.0"

--- a/test/dataModelDocument.js
+++ b/test/dataModelDocument.js
@@ -151,6 +151,7 @@ exports.dataModelDocument = {
         test.equal(xcVersionGroupEntry.isa, 'XCVersionGroup');
         test.equal(xcVersionGroupEntry.children[0], newFile.models[0].fileRef);
         test.equal(xcVersionGroupEntry.currentVersion, newFile.currentModel.fileRef);
+        test.equal(xcVersionGroupEntry.name, path.basename(singleDataModelFilePath));
         test.equal(xcVersionGroupEntry.path, singleDataModelFilePath);
         test.equal(xcVersionGroupEntry.sourceTree, '"<group>"');
         test.equal(xcVersionGroupEntry.versionGroupType, 'wrapper.xcdatamodel');

--- a/test/dataModelDocument.js
+++ b/test/dataModelDocument.js
@@ -1,0 +1,160 @@
+var jsonProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(jsonProject),
+    path = require('path'),
+    pbx = require('../lib/pbxProject'),
+    pbxFile = require('../lib/pbxFile'),
+    proj = new pbx('.'),
+    singleDataModelFilePath = __dirname + '/fixtures/single-data-model.xcdatamodeld',
+    multipleDataModelFilePath = __dirname + '/fixtures/multiple-data-model.xcdatamodeld';
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+exports.dataModelDocument = {
+    'should return a pbxFile': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+
+        test.equal(newFile.constructor, pbxFile);
+        test.done()
+    },
+    'should set a uuid on the pbxFile': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+
+        test.ok(newFile.uuid);
+        test.done()
+    },
+    'should set a fileRef on the pbxFile': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+
+        test.ok(newFile.fileRef);
+        test.done()
+    },
+    'should set an optional target on the pbxFile': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath, undefined, { target: target }),
+            target = proj.findTargetKey('TestApp');
+
+        test.equal(newFile.target, target);
+        test.done()
+    },
+    'should populate the PBXBuildFile section with 2 fields': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            buildFileSection = proj.pbxBuildFileSection(),
+            bfsLength = Object.keys(buildFileSection).length;
+
+        test.equal(59 + 1, bfsLength);
+        test.ok(buildFileSection[newFile.uuid]);
+        test.ok(buildFileSection[newFile.uuid + '_comment']);
+
+        test.done();
+    },
+    'should populate the PBXFileReference section with 2 fields for single model document': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            fileRefSection = proj.pbxFileReferenceSection(),
+            frsLength = Object.keys(fileRefSection).length;
+
+        test.equal(66 + 2, frsLength);
+        test.ok(fileRefSection[newFile.models[0].fileRef]);
+        test.ok(fileRefSection[newFile.models[0].fileRef + '_comment']);
+
+        test.done();
+    },
+    'should populate the PBXFileReference section with 2 fields for each model of a model document': function (test) {
+        var newFile = proj.addDataModelDocument(multipleDataModelFilePath),
+            fileRefSection = proj.pbxFileReferenceSection(),
+            frsLength = Object.keys(fileRefSection).length;
+
+        test.equal(66 + 2 * 2, frsLength);
+        test.ok(fileRefSection[newFile.models[0].fileRef]);
+        test.ok(fileRefSection[newFile.models[0].fileRef + '_comment']);
+        test.ok(fileRefSection[newFile.models[1].fileRef]);
+        test.ok(fileRefSection[newFile.models[1].fileRef + '_comment']);
+
+        test.done();
+    },
+    'should add to resources group by default': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+            groupChildren = proj.pbxGroupByName('Resources').children,
+            found = false;
+
+        for (var index in groupChildren) {
+            if (groupChildren[index].comment === 'single-data-model.xcdatamodeld') {
+                found = true;
+                break;
+            }
+        }
+        test.ok(found);
+        test.done();
+    },
+    'should add to group specified by key': function (test) {
+        var group = 'Frameworks',
+            newFile = proj.addDataModelDocument(singleDataModelFilePath, proj.findPBXGroupKey({ name: group }));
+            groupChildren = proj.pbxGroupByName(group).children;
+
+        var found = false;
+        for (var index in groupChildren) {
+            if (groupChildren[index].comment === path.basename(singleDataModelFilePath)) {
+                found = true;
+                break;
+            }
+        }
+        test.ok(found);
+        test.done();
+    },
+    'should add to group specified by name': function (test) {
+        var group = 'Frameworks',
+            newFile = proj.addDataModelDocument(singleDataModelFilePath, group);
+            groupChildren = proj.pbxGroupByName(group).children;
+
+        var found = false;
+        for (var index in groupChildren) {
+            if (groupChildren[index].comment === path.basename(singleDataModelFilePath)) {
+                found = true;
+                break;
+            }
+        }
+        test.ok(found);
+        test.done();
+    },
+    'should add to the PBXSourcesBuildPhase': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            sources = proj.pbxSourcesBuildPhaseObj();
+
+        test.equal(sources.files.length, 2 + 1);
+        test.done();
+    },
+    'should create a XCVersionGroup section': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            xcVersionGroupSection = proj.xcVersionGroupSection();
+
+        test.ok(xcVersionGroupSection[newFile.fileRef]);
+        test.done();
+    },
+    'should populate the XCVersionGroup comment correctly': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            xcVersionGroupSection = proj.xcVersionGroupSection(),
+            commentKey = newFile.fileRef + '_comment';
+
+        test.equal(xcVersionGroupSection[commentKey], path.basename(singleDataModelFilePath));
+        test.done();
+    },
+    'should add the XCVersionGroup object correctly': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            xcVersionGroupSection = proj.xcVersionGroupSection(),
+            xcVersionGroupEntry = xcVersionGroupSection[newFile.fileRef];
+
+        test.equal(xcVersionGroupEntry.isa, 'XCVersionGroup');
+        test.equal(xcVersionGroupEntry.children[0], newFile.models[0].fileRef);
+        test.equal(xcVersionGroupEntry.currentVersion, newFile.currentModel.fileRef);
+        test.equal(xcVersionGroupEntry.path, singleDataModelFilePath);
+        test.equal(xcVersionGroupEntry.sourceTree, '"<group>"');
+        test.equal(xcVersionGroupEntry.versionGroupType, 'wrapper.xcdatamodel');
+
+        test.done();
+    }
+}

--- a/test/fixtures/multiple-data-model.xcdatamodeld/.xccurrentversion
+++ b/test/fixtures/multiple-data-model.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>2.xcdatamodel</string>
+</dict>
+</plist>

--- a/test/fixtures/multiple-data-model.xcdatamodeld/1.xcdatamodel/contents
+++ b/test/fixtures/multiple-data-model.xcdatamodeld/1.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="15B42" minimumToolsVersion="Xcode 7.0">
+    <elements/>
+</model>

--- a/test/fixtures/multiple-data-model.xcdatamodeld/2.xcdatamodel/contents
+++ b/test/fixtures/multiple-data-model.xcdatamodeld/2.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="15B42" minimumToolsVersion="Xcode 7.0">
+    <elements/>
+</model>

--- a/test/fixtures/single-data-model.xcdatamodeld/SingleDataModel.xcdatamodel/contents
+++ b/test/fixtures/single-data-model.xcdatamodeld/SingleDataModel.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="15B42" minimumToolsVersion="Xcode 7.0">
+    <elements/>
+</model>

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -50,6 +50,13 @@ exports['lastKnownFileType'] = {
         test.done();
     },
 
+    'should detect that a .xcdatamodel path means wrapper.xcdatamodel': function (test) {
+        var sourceFile = new pbxFile('dataModel.xcdatamodel');
+
+        test.equal('wrapper.xcdatamodel', sourceFile.lastKnownFileType);
+        test.done();
+    },
+
     'should allow lastKnownFileType to be overridden': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m',
                 { lastKnownFileType: 'somestupidtype' });
@@ -71,6 +78,12 @@ exports['group'] = {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
         test.equal('Sources', sourceFile.group);
+        test.done();
+    },
+    'should be Sources for data model document files': function (test) {
+        var dataModelFile = new pbxFile('dataModel.xcdatamodeld');
+
+        test.equal('Sources', dataModelFile.group);
         test.done();
     },
     'should be Frameworks for frameworks': function (test) {


### PR DESCRIPTION
I needed a way to properly add versioned data model documents and ended up implementing it myself as part of node-xcode. It adds the .xcdatamodeld as a Source file to build file section and sources build phase, adds all of the .xcdatamodel files (versions) it contains to file reference section and creates a XCVersionGroup section entry registering the versions and specifying current one by parsing .xccurrentversion plist file (works also for single version files). Covered all of this with tests.