### PR TITLE
Add group option to addResourceFile and removeResourceFile

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -214,7 +214,14 @@ pbxProject.prototype.removeHeaderFile = function (path, opt, group) {
     }
 }
 
-pbxProject.prototype.addResourceFile = function(path, opt) {
+/**
+ *
+ * @param path {String}
+ * @param opt {Object} see pbxFile for avail options
+ * @param group {String} group key
+ * @returns {Object} file; see pbxFile
+ */
+pbxProject.prototype.addResourceFile = function(path, opt, group) {
     opt = opt || {};
 
     var file;
@@ -223,7 +230,7 @@ pbxProject.prototype.addResourceFile = function(path, opt) {
         file = this.addPluginFile(path, opt);
         if (!file) return false;
     } else {
-        file = new pbxFile(path, opt);
+        file = new pbxFile(path, opt);       
         if (this.hasFile(file.path)) return false;
     }
 
@@ -234,19 +241,32 @@ pbxProject.prototype.addResourceFile = function(path, opt) {
         correctForResourcesPath(file, this);
         file.fileRef = this.generateUuid();
     }
-
+    
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
-
+    
     if (!opt.plugin) {
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
-        this.addToResourcesPbxGroup(file);          // PBXGroup
+        if (group) {
+            this.addToPbxGroup(file, group);            //Group other than Resources (i.e. 'splash')
+        }
+        else {
+            this.addToResourcesPbxGroup(file);          // PBXGroup
+        }
+        
     }
-
+    
     return file;
 }
 
-pbxProject.prototype.removeResourceFile = function(path, opt) {
+/**
+ *
+ * @param path {String}
+ * @param opt {Object} see pbxFile for avail options
+ * @param group {String} group key
+ * @returns {Object} file; see pbxFile
+ */
+pbxProject.prototype.removeResourceFile = function(path, opt, group) {
     var file = new pbxFile(path, opt);
     file.target = opt ? opt.target : undefined;
 
@@ -254,7 +274,12 @@ pbxProject.prototype.removeResourceFile = function(path, opt) {
 
     this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
     this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
-    this.removeFromResourcesPbxGroup(file);          // PBXGroup
+    if (group) {
+        this.removeFromPbxGroup(file, group);           //Group other than Resources (i.e. 'splash')
+    }
+    else {
+        this.removeFromResourcesPbxGroup(file);          // PBXGroup
+    }    
     this.removeFromPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
 
     return file;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.3",
+  "version": "0.8.5",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/test/group.js
+++ b/test/group.js
@@ -185,7 +185,7 @@ exports.removeSourceFileFromGroup = {
 }
 
 exports.addHeaderFileToGroup = {
-    'should create group + add source file' : function(test) {
+    'should create group + add header file' : function(test) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
         var file = project.addHeaderFile('Notifications.h', {}, testKey);
 
@@ -197,7 +197,7 @@ exports.addHeaderFileToGroup = {
 }
 
 exports.removeHeaderFileFromGroup = {
-    'should create group + add source file then remove source file' : function(test) {
+    'should create group + add source file then remove header file' : function(test) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
         var file = project.addHeaderFile('Notifications.h', {}, testKey);
 
@@ -205,6 +205,36 @@ exports.removeHeaderFileFromGroup = {
         test.ok(foundInGroup);
 
         project.removeHeaderFile('Notifications.h', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(!foundInGroup);
+
+        test.done();
+    }
+}
+
+exports.addResourceFileToGroup = {
+    'should add resource file (PNG) to the splash group' : function(test) {
+        
+        var testKey = project.findPBXGroupKey({path:'splash'});
+        var file = project.addResourceFile('DefaultTest-667h.png', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(foundInGroup);
+
+        test.done();
+    }
+}
+
+exports.removeResourceFileFromGroup = {
+    'should add resource file (PNG) then remove resource file from splash group' : function(test) {
+        var testKey = project.findPBXGroupKey({path:'splash'});
+        var file = project.addResourceFile('DefaultTest-667h.png', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(foundInGroup);
+
+        project.removeResourceFile('DefaultTest-667h.png', {}, testKey);
 
         var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
         test.ok(!foundInGroup);


### PR DESCRIPTION
* Found that a group is required to be specified for certain PNG files when using the **addResourceFile** method of **pbxProject**;
* Includes unit tests
* Instrumented for **removeResourceFile** for completeness 

Example: For image file at `Resources\splash\Default-567h.png` then using **addResourceFile** would configure xcode project that file was in `Resources\Default-567h.png`
