### PR TITLE
pbxProject: pbxCopyFilesBuildPhaseObj missing 'frameworks'

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1447,6 +1447,7 @@ function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName){
         command_line_tool: 'wrapper',
         dynamic_library: 'products_directory',
         framework: 'shared_frameworks',
+        frameworks: 'frameworks',
         static_library: 'products_directory',
         unit_test_bundle: 'wrapper',
         watch_app: 'wrapper',

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -106,7 +106,7 @@ exports.addBuildPhase = {
         test.done();
     },
     'should set target to Frameworks given \'frameworks\' as target': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXCopyFilesBuildPhase', 'Copy Files', proj.getFirstTarget().uuid,  'frameworks').buildPhase;
+        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXCopyFilesBuildPhase', 'Copy Files', proj.getFirstTarget().uuid, 'frameworks').buildPhase;
         test.equal(buildPhase.dstSubfolderSpec, 10);
         test.done();
     },

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -104,5 +104,10 @@ exports.addBuildPhase = {
         
         test.deepEqual(initialFileReferenceSectionItemsCount.length, afterAdditionBuildFileSectionItemsCount.length - 2);
         test.done();
-    }
+    },
+    'should set target to Frameworks given \'frameworks\' as target': function (test) {
+        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXCopyFilesBuildPhase', 'Copy Files', proj.getFirstTarget().uuid,  'frameworks').buildPhase;
+        test.equal(buildPhase.dstSubfolderSpec, 10);
+        test.done();
+    },
 }

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -219,6 +219,9 @@ exports.addFramework = {
         var newFile = proj.addFramework('/path/to/SomeEmbeddableCustom.framework', {customFramework: true, embed: true}),
             frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
 
+        var buildPhaseInPbx = proj.pbxEmbedFrameworksBuildPhaseObj();
+        test.equal(buildPhaseInPbx.dstSubfolderSpec, 10);
+
         test.equal(frameworks.files.length, 1);
         test.done();
     },


### PR DESCRIPTION
Previously there was no way to access SUBFOLDERSPEC_BY_DESTINATION.frameworks