### PR TITLE
Fixes #97

### DIFF
--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -165,8 +165,7 @@ function defaultGroup(fileRef) {
 
 function pbxFile(filepath, opt) {
     var opt = opt || {};
-
-    self = this;
+    var self = this;
 
     this.basename = path.basename(filepath);
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);


### PR DESCRIPTION
In `jest` (test runner) and react-native environment, the assignment is going to be ignored and the `self` remains pointing to whatever react-native defined for the sake of testing. Adding missing var here.

CC: @davidaurelio