### PR TITLE
Function to get all targets

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1682,6 +1682,29 @@ pbxProject.prototype.getFirstTarget = function() {
     }
 }
 
+//Returns an array of objects containing the uuid and target
+pbxProject.prototype.getAllTargets = function() {
+    //Holds all target json information
+    var targets = [];
+
+    //Get raw target info
+    var targetUuids = this.getFirstProject()['firstProject']['targets'];
+
+    //for each target index
+    for (var uuid in targetUuids) {
+        var uuidValue = uuid.value;
+        var target = this.pbxNativeTargetSection()[uuidValue];
+
+        targets.push({
+          uuid: uuidValue,
+          target: target
+        });
+    }
+
+    return targets;
+
+}
+
 /*** NEW ***/
 
 pbxProject.prototype.addToPbxGroup = function (file, groupKey) {


### PR DESCRIPTION
Just a simple function to return an array of objects describing the targets. This is necessary for a soon to be implemented feature of rnpm to link a project to all targets, instead of just the first.