### PR TITLE
Fix maximum callstack when merging two strings

### DIFF
--- a/lib/parser/pbxproj.js
+++ b/lib/parser/pbxproj.js
@@ -1864,7 +1864,7 @@ function peg$parse(input, options) {
 
 
       function merge_obj(obj, secondObj) {
-          if (!obj)
+          if (!obj || typeof(obj) !== "object")
               return secondObj;
 
           for(var i in secondObj)

--- a/lib/parser/pbxproj.pegjs
+++ b/lib/parser/pbxproj.pegjs
@@ -1,6 +1,6 @@
 {
     function merge_obj(obj, secondObj) {
-        if (!obj)
+        if (!obj || typeof(obj) !== "object")
             return secondObj;
 
         for(var i in secondObj)


### PR DESCRIPTION
Whenever trying to merge two string values maximum callstack error is thrown.
Fix it by simply returning the second occurrence rather than the first if the type of the values differs from object.

For a simple repro:
```JavaScript
function merge_obj(obj, secondObj) {
    	if (!obj)
   		return secondObj;
 
         for(var i in secondObj)
             obj[i] = merge_obj(obj[i], secondObj[i]);

         return obj;
}

merge_obj("test", "other")
```

Ping @alunny for review.