### PR TITLE
Fix 'searchPaths.filter is not a function' error #133

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1111,6 +1111,9 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
         searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths) {
+            if (typeof searchPaths === "string") {
+                searchPaths = [searchPaths];
+            }
             var matches = searchPaths.filter(function(p) {
                 return p.indexOf(new_path) > -1;
             });
@@ -1158,6 +1161,9 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function(file) {
         searchPaths = buildSettings[SEARCH_PATHS];
 
         if (searchPaths) {
+            if (typeof searchPaths === "string") {
+                searchPaths = [searchPaths];
+            }
             var matches = searchPaths.filter(function(p) {
                 return p.indexOf(new_path) > -1;
             });
@@ -1810,7 +1816,11 @@ pbxProject.prototype.getPBXGroupByKey = function(key) {
 };
 
 pbxProject.prototype.getPBXVariantGroupByKey = function(key) {
-    return this.hash.project.objects['PBXVariantGroup'][key];
+    var pbxVariantGroup = this.hash.project.objects['PBXVariantGroup']
+    if (key && pbxVariantGroup) {
+        return pbxVariantGroup[key];
+    }
+    return undefined
 };
 
 


### PR DESCRIPTION
See #133 and [issue 13160 on react-native](https://github.com/facebook/react-native/issues/13160).

I've started from [this comment](https://github.com/facebook/react-native/issues/13160#issuecomment-335225385) from JperF and fixed it to work on my specific app.
So far so good for me :-)